### PR TITLE
In non-overlay network mode, allow selecting which network is "external"

### DIFF
--- a/lib/backends/sdc/containers.js
+++ b/lib/backends/sdc/containers.js
@@ -163,7 +163,8 @@ function addNetworksToPayload(opts, container, payload, callback) {
     // No fabrics configured - fall back to provisioning on the external
     // network
 
-    listNetworks(opts, {name: 'external'}, function (err, networks) {
+    var netName = opts.config.externalNetwork || 'external';
+    listNetworks(opts, {name: netName}, function (err, networks) {
         var external_net;
         log.debug({err: err, res: networks}, 'list external networks');
 
@@ -174,8 +175,7 @@ function addNetworksToPayload(opts, container, payload, callback) {
 
         networks.forEach(function (n) {
             if (!external_net
-                && n.name === 'external'
-                && n.nic_tag === 'external') {
+                && n.name === netName) {
 
                 external_net = n.uuid;
             }
@@ -183,7 +183,7 @@ function addNetworksToPayload(opts, container, payload, callback) {
 
         if (!external_net) {
             callback(new errors.DockerError(
-                'unable to find external network uuid'));
+                'unable to find "'+netName+'" network uuid'));
             return;
         }
 

--- a/sapi_manifests/docker/template
+++ b/sapi_manifests/docker/template
@@ -8,6 +8,7 @@
     "backend": "sdc",
     "defaultMemory": {{#DEFAULT_MEMORY}}{{{DEFAULT_MEMORY}}}{{/DEFAULT_MEMORY}}{{^DEFAULT_MEMORY}}1024{{/DEFAULT_MEMORY}},
     "packagePrefix": "{{#PACKAGE_PREFIX}}{{{PACKAGE_PREFIX}}}{{/PACKAGE_PREFIX}}{{^PACKAGE_PREFIX}}sdc_{{/PACKAGE_PREFIX}}",
+    "externalNetwork": "{{#EXTERNAL_NET}}{{{EXTERNAL_NET}}}{{/EXTERNAL_NET}}{{^EXTERNAL_NET}}external{{/EXTERNAL_NET}}",
     "overlay": {
 {{#fabric_cfg}}
         "externalPool": "{{{sdc_nat_pool}}}",


### PR DESCRIPTION
In particular, don't enforce that "external" must be on a nic_tag named "external". This makes sdc-docker easier to try out in pre-existing SDC deployments that don't have overlays enabled yet.

This can take in a metadata option, EXTERNAL_NET to choose a name other than "external" to look for when selecting the network for docker containers.