### PR TITLE
Doc update on docker commands and features

### DIFF
--- a/docs/api/commands/history.md
+++ b/docs/api/commands/history.md
@@ -34,4 +34,4 @@ There is no known divergence between the Triton SDC Docker and Docker Inc. imple
 
 ## Related
 
-- Insert a list of related Docker and CloudAPI methods here
+- [`docker inspect`](../commands/inspect.md) 

--- a/docs/api/commands/images.md
+++ b/docs/api/commands/images.md
@@ -121,4 +121,6 @@ There is no known divergence between the Triton SDC Docker and Docker Inc. imple
 
 ## Related
 
+- [`docker inspect`](../commands/inspect.md) 
+- [`docker history`](../commands/history.md) 
 - [`docker rmi`](../commands/rmi.md) 

--- a/docs/api/commands/login.md
+++ b/docs/api/commands/login.md
@@ -1,9 +1,29 @@
 # login
 
+    Usage: docker login [OPTIONS] [SERVER]
+
+    Register or log in to a Docker registry server, if no server is specified "https://index.docker.io/v1/" is the default.
+
+      -e, --email=""       Email
+      -p, --password=""    Password
+      -u, --username=""    Username
+
+
+## Examples
+
+    $ docker login
+
+If you want to login to a self-hosted registry you can specify this by adding the server name.
+
+    $ docker login myrepo.example.com
+
 ## Divergence
 
-- This command is currently unimplemented. Follow [DOCKER-73](http://smartos.org/bugview/DOCKER-73) for progress updates.
+The SDC Docker implementation does not support third-party registries at this time. Follow [DOCKER-380](https://smartos.org/bugview/DOCKER-380) for progress updates.
+
+Self-hosted private repos that use self-signed certificates are not supported. Follow [DOCKER-382](https://smartos.org/bugview/DOCKER-382) for progress updates. See also [repos](../features/repos.md).
+
+Please contact Joyent support or file a ticket if you discover any additional divergence.
 
 ## Related
-
-- Insert a list of related Docker and CloudAPI methods here
+- [`docker logout`](../commands/logout.md)

--- a/docs/api/commands/login.md
+++ b/docs/api/commands/login.md
@@ -21,7 +21,7 @@ If you want to login to a self-hosted registry you can specify this by adding th
 
 The SDC Docker implementation does not support third-party registries at this time. Follow [DOCKER-380](https://smartos.org/bugview/DOCKER-380) for progress updates.
 
-Self-hosted private repos that use self-signed certificates are not supported. Follow [DOCKER-382](https://smartos.org/bugview/DOCKER-382) for progress updates. See also [repos](../features/repos.md).
+Self-hosted private repos that use self-signed certificates are not supported. Follow [DOCKER-382](https://smartos.org/bugview/DOCKER-382) for progress updates. See also [Private repositories](../features/repos.md).
 
 Please contact Joyent support or file a ticket if you discover any additional divergence.
 

--- a/docs/api/commands/logout.md
+++ b/docs/api/commands/logout.md
@@ -1,9 +1,21 @@
 # logout
 
+    Usage: docker logout [SERVER]
+
+    Log out from a Docker registry, if no server is specified "https://index.docker.io/v1/" is the default.
+
+## Examples
+
+    $ docker logout 
+    
+If you want to logout from a self-hosted registry you can specify this by adding the server name.
+
+    $ docker logout myrepo.example.com
+
 ## Divergence
 
-- This command is currently unimplemented. Follow [DOCKER-73](http://smartos.org/bugview/DOCKER-73) for progress updates.
+There is no known divergence between the Triton SDC Docker and Docker Inc. implementations of this method. Please contact Joyent support or file a ticket if you discover any.
 
 ## Related
+- [`docker login`](../commands/login.md)
 
-- Insert a list of related Docker and CloudAPI methods here

--- a/docs/api/commands/ps.md
+++ b/docs/api/commands/ps.md
@@ -62,7 +62,7 @@ Please contact Joyent support or file a ticket if you discover any additional di
 
 ## Related
 
-- [`docker stop`](../commands/stop.md) as in `docker stop $(docker ps -a -q)`
+- [`docker inspect`](../commands/inspect.md) as in `docker inspect $(docker ps -l -q)`
 - [`docker rm`](../commands/rm.md) as in `docker rm $(docker ps -a -q)`
 - [`sdc-listmachines`](https://apidocs.joyent.com/cloudapi/#ListMachines) and `GET /my/machines` in CloudAPI
 - [`vmadm list`](https://smartos.org/man/1m/vmadm) in SDC private API

--- a/docs/api/commands/search.md
+++ b/docs/api/commands/search.md
@@ -23,4 +23,4 @@ There is no known divergence between the Triton SDC Docker and Docker Inc. imple
 
 ## Related
 
-- Insert a list of related Docker and CloudAPI methods here
+- [`docker pull`](../commands/pull.md) 

--- a/docs/api/features/networks.md
+++ b/docs/api/features/networks.md
@@ -8,6 +8,11 @@ Address Translation](http://en.wikipedia.org/wiki/Network_address_translation).
 Each default fabric network is private to a user - one user's containers cannot
 connect to another's fabric IP addresses, and vice-versa.
 
+To isolate the traffic between different applications or groups of applications,
+users may use the CloudAPI to create additional networks on their fabrics.
+Any of these user-defined networks can be designated as the 'default' network 
+to be used for provisioning Docker containers.
+
 All docker containers owned by a user have firewalls enabled by default, and
 their default policy is to block all incoming traffic and allow all outbound
 traffic. All docker VMs have a
@@ -26,3 +31,10 @@ is not supported at this time.
 
 If fabric networking is not enabled, all docker containers are provisioned with
 a nic on the 'external' network by default.
+
+
+## Related
+
+- [`sdc-fabric vlan`](https://apidocs.joyent.com/cloudapi/#CreateFabricVlan) and `POST /my/fabrics/default/vlans` in CloudAPI
+- [`sdc-fabric network`](https://apidocs.joyent.com/cloudapi/#CreateFabricNetwork) and `POST /my/fabrics/default/vlans/:id/networks` in CloudAPI
+- [`sdc-fabric networki set-default`](https://apidocs.joyent.com/cloudapi/#SetDefaultNetwork) and `PUT /my/config` in CloudAPI

--- a/docs/api/features/networks.md
+++ b/docs/api/features/networks.md
@@ -9,7 +9,7 @@ Each default fabric network is private to a user - one user's containers cannot
 connect to another's fabric IP addresses, and vice-versa.
 
 To isolate the traffic between different applications or groups of applications,
-users may use the CloudAPI to create additional networks on their fabrics.
+users may use the CloudAPI to create additional networks on their fabric.
 Any of these user-defined networks can be designated as the 'default' network 
 to be used for provisioning Docker containers. When you change the 'default'
 network, it affects only the newly provisioned containers.

--- a/docs/api/features/networks.md
+++ b/docs/api/features/networks.md
@@ -11,7 +11,8 @@ connect to another's fabric IP addresses, and vice-versa.
 To isolate the traffic between different applications or groups of applications,
 users may use the CloudAPI to create additional networks on their fabrics.
 Any of these user-defined networks can be designated as the 'default' network 
-to be used for provisioning Docker containers.
+to be used for provisioning Docker containers. When you change the 'default'
+network, it affects only the newly provisioned containers.
 
 All docker containers owned by a user have firewalls enabled by default, and
 their default policy is to block all incoming traffic and allow all outbound

--- a/docs/api/features/networks.md
+++ b/docs/api/features/networks.md
@@ -36,6 +36,6 @@ a nic on the 'external' network by default.
 
 ## Related
 
-- [`sdc-fabric vlan`](https://apidocs.joyent.com/cloudapi/#CreateFabricVlan) and `POST /my/fabrics/default/vlans` in CloudAPI
+- [`sdc-fabric vlan`](https://apidocs.joyent.com/cloudapi/#CreateFabricVLAN) and `POST /my/fabrics/default/vlans` in CloudAPI
 - [`sdc-fabric network`](https://apidocs.joyent.com/cloudapi/#CreateFabricNetwork) and `POST /my/fabrics/default/vlans/:id/networks` in CloudAPI
-- [`sdc-fabric networki set-default`](https://apidocs.joyent.com/cloudapi/#SetDefaultNetwork) and `PUT /my/config` in CloudAPI
+- [`sdc-fabric networki set-default`](https://apidocs.joyent.com/cloudapi/#UpdateConfig) and `PUT /my/config` in CloudAPI

--- a/docs/api/features/repos.md
+++ b/docs/api/features/repos.md
@@ -1,8 +1,8 @@
 # Private repositories
 
-SDC-Docker supports the use of Docker images maintained in Docker Hub's public or private repos, or in self-hosted Docker repos hosted in your own application environment.  Images are uniquely identified by the repo namespace, i.e. [REPOHOST_OR_NAMESPACE/]IMAGE_NAME[:TAG]. You may connect to multiple repos at the same time and pull images from them without having to switch from one to another.
+SDC-Docker supports the use of Docker images maintained in Docker Hub's public or private repos, or in self-hosted Docker repos in your own application environment.  Images are uniquely identified by the repo namespace, i.e. [REPOHOST_OR_NAMESPACE/]IMAGE_NAME[:TAG]. You may connect to multiple repos at the same time and pull images from them without having to switch from one to another.
 
-## Using images with private repo hosted on Docker Hub
+## Using images in Docker Hub private repo
 
 If no server is specified, "https://index.docker.io/v1/" is the default. For example:
 
@@ -22,7 +22,7 @@ If no server is specified, "https://index.docker.io/v1/" is the default. For exa
 
 In `docker pull` and `docker run`, the image search goes across Docker Hub's public repo and the private repos you have logged in. As with Docker Inc. docker, `docker search` operation is confined to only the public repo.
 
-## Using images with private repo hosted outside of Docker Hub
+## Using images in self-hosted private repo
 
 All self-hosted private repos should have a fully qualified domain name and an authority-signed certificate. The end-point should be referenced in the image name when using docker pull/run/create operations.
 

--- a/docs/api/features/repos.md
+++ b/docs/api/features/repos.md
@@ -1,43 +1,40 @@
-Private repositories
+# Private repositories
 
-Docker images may be maintained in Docker Hub's public or private repos, or in private Docker repos hosted in your own application environment. Private repos are accessible from sdc-docker once you have authenticated to them. Images are uniquely identified by the repo and user namespace - [REPO_HOST/]IMAGE_NAME[:TAG]. You may connect to multiple repos at the same time and pull images from them without having to switch from one to another.
+SDC-Docker supports the use of Docker images maintained in Docker Hub's public or private repos, or in self-hosted Docker repos hosted in your own application environment.  Images are uniquely identified by the repo namespace, i.e. [REPOHOST_OR_NAMESPACE/]IMAGE_NAME[:TAG]. You may connect to multiple repos at the same time and pull images from them without having to switch from one to another.
 
 ## Using images with private repo hosted on Docker Hub
 
-The repo is implicity referenced when no repo end-point is specified. For example:
+If no server is specified, "https://index.docker.io/v1/" is the default. For example:
 
-$ docker login
-Username: jill_user
-Password: 
-Email: jill_user@example.com
-WARNING: login credentials saved in /Users/jill_user/.dockercfg.
-Login Succeeded
+    $ docker login
+    Username: myrepo
+    Password: 
+    Email: user@example.com
 
-$ docker pull jill_user/busybox
-Pulling repository docker.io/jill_user/busybox
-:
+    $ docker pull myrepo/busybox
+    Pulling repository docker.io/myrepo/busybox
+    ...
 
-$ docker run -it jill_user/busybox bash
+    $ docker run -it myrepo/busybox bash
 
-$ docker logout
-Remove login credentials for https://index.docker.io/v1/
+    $ docker logout
+    Remove login credentials for https://index.docker.io/v1/
 
-The lookup of the image specified goes across Docker Hub's public repo and the private repo you are currently logged in to.
-
+In `docker pull` and `docker run`, the image search goes across Docker Hub's public repo and the private repos you have logged in. As with Docker Inc. docker, `docker search` operation is confined to only the public repo.
 
 ## Using images with private repo hosted outside of Docker Hub
 
-All private repos should have a fully qualified domain name and an authority-signed certificate. The end-point should be referenced in the image name when using docker pull/run/create operations.
+All self-hosted private repos should have a fully qualified domain name and an authority-signed certificate. The end-point should be referenced in the image name when using docker pull/run/create operations.
 
-$ docker login myrepo.example.com
-Username: jill_user
-Password: 
-Email: jill_user@example.com
+    $ docker login myrepo.example.com
+    Username: myrepo
+    Password: 
+    Email: user@example.com
 
-$ docker pull jill-repo.example.com/busybox
+    $ docker pull myrepo.example.com/busybox
 
-$ docker run -it jill-repo.example.com/busybox bash
+    $ docker run -it myrepo.example.com/busybox bash
 
-$ docker logout jill-repo.example.com
+    $ docker logout myrepo.example.com
  
 

--- a/docs/api/features/repos.md
+++ b/docs/api/features/repos.md
@@ -1,6 +1,6 @@
 # Private repositories
 
-SDC-Docker supports the use of Docker images maintained in Docker Hub's public or private repos, or in self-hosted Docker repos in your own application environment.  Images are uniquely identified by the repo namespace, i.e. [REPOHOST_OR_NAMESPACE/]IMAGE_NAME[:TAG]. You may connect to multiple repos at the same time and pull images from them without having to switch from one to another.
+SDC-Docker supports the use of Docker images maintained in Docker Hub's public or private repos, or in self-hosted Docker repos in your own application environment.  Images are uniquely identified by the repo endpoint and namespace, i.e. [REPOHOST_OR_NAMESPACE/]IMAGE_NAME[:TAG]. You may connect to multiple repos at the same time and pull images from them without having to switch from one to another.
 
 ## Using images in Docker Hub private repo
 
@@ -20,16 +20,13 @@ If no server is specified, "https://index.docker.io/v1/" is the default. For exa
     $ docker logout
     Remove login credentials for https://index.docker.io/v1/
 
-In `docker pull` and `docker run`, the image search goes across Docker Hub's public repo and the private repos you have logged in. As with Docker Inc. docker, `docker search` operation is confined to only the public repo.
+`docker pull` and `docker run` operations go across Docker Hub's public repo and the private repos you have logged in. `docker search` operation is confined to only the public repo, as with Docker Inc. docker.
 
 ## Using images in self-hosted private repo
 
 All self-hosted private repos should have a fully qualified domain name and an authority-signed certificate. The end-point should be referenced in the image name when using docker pull/run/create operations.
 
     $ docker login myrepo.example.com
-    Username: myrepo
-    Password: 
-    Email: user@example.com
 
     $ docker pull myrepo.example.com/busybox
 

--- a/docs/api/features/repos.md
+++ b/docs/api/features/repos.md
@@ -1,0 +1,43 @@
+Private repositories
+
+Docker images may be maintained in Docker Hub's public or private repos, or in private Docker repos hosted in your own application environment. Private repos are accessible from sdc-docker once you have authenticated to them. Images are uniquely identified by the repo and user namespace - [REPO_HOST/]IMAGE_NAME[:TAG]. You may connect to multiple repos at the same time and pull images from them without having to switch from one to another.
+
+## Using images with private repo hosted on Docker Hub
+
+The repo is implicity referenced when no repo end-point is specified. For example:
+
+$ docker login
+Username: jill_user
+Password: 
+Email: jill_user@example.com
+WARNING: login credentials saved in /Users/jill_user/.dockercfg.
+Login Succeeded
+
+$ docker pull jill_user/busybox
+Pulling repository docker.io/jill_user/busybox
+:
+
+$ docker run -it jill_user/busybox bash
+
+$ docker logout
+Remove login credentials for https://index.docker.io/v1/
+
+The lookup of the image specified goes across Docker Hub's public repo and the private repo you are currently logged in to.
+
+
+## Using images with private repo hosted outside of Docker Hub
+
+All private repos should have a fully qualified domain name and an authority-signed certificate. The end-point should be referenced in the image name when using docker pull/run/create operations.
+
+$ docker login myrepo.example.com
+Username: jill_user
+Password: 
+Email: jill_user@example.com
+
+$ docker pull jill-repo.example.com/busybox
+
+$ docker run -it jill-repo.example.com/busybox bash
+
+$ docker logout jill-repo.example.com
+ 
+


### PR DESCRIPTION
Please review, make changes and merge as appropriate. Note that the related links in networks.md need to be marked up in the Cloud API docs (https://apidocs.joyent.com/cloudapi/) as part of the Cloud API doc refresh to expose the new fabric API.