### PR TITLE
DOCKER-458: Can't specify memory for containers with 1.7 client

### DIFF
--- a/lib/backends/sdc/containers.js
+++ b/lib/backends/sdc/containers.js
@@ -927,14 +927,18 @@ function getPackage(opts, container, callback) {
     }, function (err, pkgs, count) {
             var candidate = {};
             var constraints = {};
-            var memory;
+            // Starting with docker client version 1.7, the memory
+            // for the host is passed in the container.HostConfig object,
+            // not directly in the container object.
+            var hostConfig = container.HostConfig || {};
+            var memory = Number(container.Memory || hostConfig.Memory);
 
-            if (container.Memory) {
+            if (memory) {
                 // Values always come in bytes from client, but we want MiB.
-                memory = Number(container.Memory) / (1024 * 1024);
-                constraints.memory =
-                    common.humanSizeFromBytes(container.Memory);
+                constraints.memory = common.humanSizeFromBytes(memory);
+                memory = memory / (1024 * 1024);
             }
+
             if (isNaN(memory)) {
                 // value of default is in MiB
                 memory = opts.config.defaultMemory;

--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -1,0 +1,44 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (c) 2015, Joyent, Inc.
+ */
+
+var assert = require('assert-plus');
+var path = require('path');
+var fs = require('fs');
+
+function loadConfigSync(opts) {
+    assert.object(opts, 'opts');
+    assert.object(opts.log, 'opts.log');
+
+    var configPath = path.resolve(__dirname, '..', 'etc', 'config.json');
+    opts.log.info('Loading config from "%s"', configPath);
+    var config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+
+    // Validation. XXX backend-specific config validation should not be here.
+    assert.number(config.port, 'config.port');
+    assert.number(config.defaultMemory, 'config.defaultMemory');
+    assert.string(config.packagePrefix, 'config.packagePrefix');
+    assert.string(config.logLevel, 'config.logLevel');
+    assert.object(config.cnapi, 'config.cnapi');
+    assert.string(config.cnapi.url, 'config.cnapi.url');
+    assert.object(config.imgapi, 'config.imgapi');
+    assert.string(config.imgapi.url, 'config.imgapi.url');
+    assert.object(config.napi, 'config.napi');
+    assert.string(config.napi.url, 'config.papi.url');
+    assert.object(config.papi, 'config.napi');
+    assert.string(config.papi.url, 'config.papi.url');
+    assert.object(config.vmapi, 'config.vmapi');
+    assert.string(config.vmapi.url, 'config.vmapi.url');
+
+    return config;
+}
+
+module.exports = {
+    loadConfigSync: loadConfigSync
+};

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -44,7 +44,7 @@ var models = require('./models');
 var SocketManager = require('./socket-manager');
 var upgrade = require('./upgrade');
 var wfapi = require('./wfapi');
-
+var configLoader = require('./config-loader');
 
 
 //---- globals
@@ -55,37 +55,6 @@ var TLS_CERT = '/data/tls/cert.pem';
 var VERSION = JSON.parse(fs.readFileSync(path.normalize(
     __dirname + '/../package.json'), 'utf8')).version;
 var request_seq_id = 0;
-
-
-
-//---- internal support stuff
-
-function loadConfigSync(opts) {
-    assert.object(opts, 'opts');
-    assert.object(opts.log, 'opts.log');
-
-    var configPath = path.resolve(__dirname, '..', 'etc', 'config.json');
-    opts.log.info('Loading config from "%s"', configPath);
-    var config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-
-    // Validation. XXX backend-specific config validation should not be here.
-    assert.number(config.port, 'config.port');
-    assert.number(config.defaultMemory, 'config.defaultMemory');
-    assert.string(config.packagePrefix, 'config.packagePrefix');
-    assert.string(config.logLevel, 'config.logLevel');
-    assert.object(config.cnapi, 'config.cnapi');
-    assert.string(config.cnapi.url, 'config.cnapi.url');
-    assert.object(config.imgapi, 'config.imgapi');
-    assert.string(config.imgapi.url, 'config.imgapi.url');
-    assert.object(config.napi, 'config.napi');
-    assert.string(config.napi.url, 'config.papi.url');
-    assert.object(config.papi, 'config.napi');
-    assert.string(config.papi.url, 'config.papi.url');
-    assert.object(config.vmapi, 'config.vmapi');
-    assert.string(config.vmapi.url, 'config.vmapi.url');
-
-    return config;
-}
 
 
 
@@ -625,7 +594,7 @@ function main() {
         serializers: sbs.serializers
     });
 
-    var config = loadConfigSync({log: log});
+    var config = configLoader.loadConfigSync({log: log});
     log.level(config.logLevel);
 
     // EXPERIMENTAL

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -1119,6 +1119,7 @@ function createDockerContainer(opts, callback) {
     var t = opts.test;
     var log = dockerClient.log;
     var response = {};
+    var apiVersion = opts.apiVersion || 'v1.16';
 
     if (opts.extra) {
         for (var e in opts.extra) {
@@ -1165,7 +1166,8 @@ function createDockerContainer(opts, callback) {
 
         function (next) {
             // Post create request
-            dockerClient.post('/v1.16/containers/create', payload, onpost);
+            dockerClient.post('/' + apiVersion + '/containers/create',
+                              payload, onpost);
             function onpost(err, res, req, body) {
                 if (opts.expectedErr) {
                     common.expErr(t, err, opts.expectedErr, callback);


### PR DESCRIPTION
Instead of getting the value `Memory` from just the root of the container
object, which is where docker clients < 1.7 put it, we also check in
`container.HostConfig.Memory`, which is where docker clients >= 1.7 put
it.

This commit adds integration tests for this change. These tests create
docker containers with a memory value different than the default memory
value and mimic the behavior of docker clients pre and post 1.7.

This commit also moves `loadConfigSync` to its own module so that it can
be used by tests that need to load the configuration to lookup default
values (such as `defaultMemory` in this case).