### PR TITLE
DOCKER-458: handle different API versions explicitly

### DIFF
--- a/lib/backends/sdc/containers.js
+++ b/lib/backends/sdc/containers.js
@@ -918,6 +918,7 @@ function getPackage(opts, container, callback) {
     assert.string(opts.config.packagePrefix, 'opts.config.packagePrefix');
     assert.object(opts.log, 'opts.log');
     assert.object(opts.account, 'opts.account');
+    assert.number(opts.clientApiVersion, 'opts.clientApiVersion');
 
     var log = opts.log;
     var papi = getPapiClient(opts.config.papi);
@@ -927,11 +928,17 @@ function getPackage(opts, container, callback) {
     }, function (err, pkgs, count) {
             var candidate = {};
             var constraints = {};
-            // Starting with docker client version 1.7, the memory
+            var memory;
+            // Starting with docker API v1.18, the memory value
             // for the host is passed in the container.HostConfig object,
             // not directly in the container object.
-            var hostConfig = container.HostConfig || {};
-            var memory = Number(container.Memory || hostConfig.Memory);
+            if (opts.clientApiVersion < 1.18) {
+                if (container.Memory)
+                    memory = Number(container.Memory);
+            } else {
+                if (container.HostConfig && container.HostConfig.Memory)
+                    memory = Number(container.HostConfig.Memory);
+            }
 
             if (memory) {
                 // Values always come in bytes from client, but we want MiB.
@@ -1115,6 +1122,7 @@ function buildVmPayload(opts, container, callback) {
     assert.object(opts.image, 'opts.image');
     assert.object(opts.vmapi, 'opts.vmapi'); // vmapi client
     assert.object(container, 'container');
+    assert.number(opts.clientApiVersion, 'opts.clientApiVersion');
 
     var bad_host_volumes = [];
     var binds;
@@ -1892,6 +1900,7 @@ function createContainer(opts, callback) {
     assert.optionalObject(opts.log, 'opts.log');
     assert.string(opts.req_id, 'opts.req_id');
     assert.object(opts.account, 'opts.account');
+    assert.number(opts.clientApiVersion, 'opts.clientApiVersion');
 
     var log = opts.log || this.log;
     var name = opts.name;
@@ -1918,7 +1927,8 @@ function createContainer(opts, callback) {
             log: log,
             req_id: opts.req_id,
             account: opts.account,
-            vmapi: vmapi
+            vmapi: vmapi,
+            clientApiVersion: opts.clientApiVersion
         }, container, function (err, _vm_payload) {
             if (err) {
                 return cb(err);

--- a/lib/endpoints/containers.js
+++ b/lib/endpoints/containers.js
@@ -126,7 +126,8 @@ function containerCreate(req, res, next) {
         log: log,
         name: req.query.name,
         payload: req.body,
-        req_id: req.getId()
+        req_id: req.getId(),
+        clientApiVersion: req.clientApiVersion
     };
 
     if (!create_opts.name) {


### PR DESCRIPTION
This change addresses [@trentm's code review comments](https://github.com/joyent/sdc-docker/commit/c0cc2ee5c4bb77416c15f8a29bf60e37f83760d3#commitcomment-12159778) about handling different API versions more explicitly regarding the `Memory` value passed by the docker client when creating a container.

We could be "more liberal in what we accept" by also accepting `container.Memory` even when the client's API version is >= 1.18, and by accepting `container.HostConfig.Memory` even when the client's API version is < 1.18, but we would use them as fallbacks.

Also, not necessarily a question for this PR but maybe to avoid problems further down the road, I'm not a big fan of checking the client's API version in code that is not strictly at the API/HTTP params handling layer. It seems that it's how different client API versions are currently handled, so I did it that way. 

Would it make sense to create models (for containers and other objects that are used in the API's input/output) that are "version agnostic" to use at the "model" layer, and then parse/send them using the correct format depending on the client API version at the API/HTTP layer?

@trentm @joshwilsdon @twhiteman Thoughts?

