### PR TITLE
DOCKER-483: Audit log causes out of memory crashes

### DIFF
--- a/lib/audit-logger.js
+++ b/lib/audit-logger.js
@@ -1,0 +1,161 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (c) 2015, Joyent, Inc.
+ */
+
+var assert = require('assert-plus');
+var bunyan = require('bunyan');
+
+var HttpError = require('restify').HttpError;
+
+// Default maximum length for requests/responses body that are logged
+// is 10 KBs. This can be overriden with the option object passed
+// to auditLogger.
+var DEFAULT_MAX_LOG_BODY_LENGTH = 10 * 1024;
+
+function getBodyToLog(body, options) {
+    var loggedBody;
+    options = options || {};
+
+    assert.object(options, 'options');
+
+    var maxLength = options.maxLength
+        || DEFAULT_MAX_LOG_BODY_LENGTH;
+
+    if (body && options.log !== false
+        && (!Buffer.isBuffer(body) || options.logBuffers === true)) {
+        loggedBody = body;
+
+        if (loggedBody.length > maxLength)
+            loggedBody = loggedBody.slice(0, maxLength) + '...';
+    }
+
+    return loggedBody;
+}
+
+function getResponseBodyToLog(res, responseOptions) {
+    var body;
+
+    if (res._body instanceof HttpError) {
+        body = res._body.body;
+    } else {
+        body = res._body;
+    }
+
+    return getBodyToLog(body, responseOptions);
+}
+
+///--- API
+
+/**
+ * This function was copied verbatim from restify's audit logger and changed
+ * slightly so that it could be more flexible, and have more sensible defaults:
+ *
+ * - The options object now accepts "responseBody" and "requestBody" subobjects
+ * so that options can be set separately for the response body or request body
+ * respectively.
+ *
+ * - Each of these options sub-objects support the following properties:
+ *
+ *  * log: if true, the request or the response's body will be logged.
+ *  * buffers: if true, requests/responses' bodies that are buffers will
+ *    be logged. False by default.
+ *  * maxLength: allows to specify the maximum size of body's data that
+ *    will be logged. DEFAULT_MAX_LOG_BODY_LENGTH (currently 10KBs) by default.
+ *
+ * Returns a Bunyan audit logger suitable to be used in a server.on('after')
+ * event.  I.e.:
+ *
+ * server.on('after', restify.auditLogger({ log: myAuditStream }));
+ *
+ * This logs at the INFO level.
+ *
+ * @param {Object} options at least a bunyan logger (log).
+ * @return {Function} to be used in server.after.
+ */
+function auditLogger(options) {
+    assert.object(options, 'options');
+    assert.object(options.log, 'options.log');
+    var errSerializer = bunyan.stdSerializers.err;
+
+    if (options.log.serializers && options.log.serializers.err) {
+        errSerializer = options.log.serializers.err;
+    }
+
+    var log = options.log.child({
+        audit: true,
+        serializers: {
+            err: errSerializer,
+            req: function auditRequestSerializer(req) {
+                if (!req)
+                    return (false);
+
+                var timers = {};
+                (req.timers || []).forEach(function (time) {
+                    var t = time.time;
+                    var _t = Math.floor((1000000 * t[0])
+                        + (t[1] / 1000));
+                    timers[time.name] = _t;
+                });
+                return ({
+                    method: req.method,
+                    url: req.url,
+                    headers: req.headers,
+                    httpVersion: req.httpVersion,
+                    trailers: req.trailers,
+                    version: req.version(),
+                    body: getBodyToLog(req.body, options.requestBody),
+                    timers: timers
+                });
+            },
+            res: function auditResponseSerializer(res) {
+                if (!res)
+                    return (false);
+
+
+                var body = getResponseBodyToLog(res, options.responseBody);
+
+                return ({
+                    statusCode: res.statusCode,
+                    headers: res._headers,
+                    trailer: res._trailer || false,
+                    body: body
+                });
+            }
+        }
+    });
+
+    function audit(req, res, route, err) {
+        var latency = res.get('Response-Time');
+        if (typeof (latency) !== 'number')
+            latency = Date.now() - req._time;
+
+        var obj = {
+            remoteAddress: req.connection.remoteAddress,
+            remotePort: req.connection.remotePort,
+            req_id: req.getId(),
+            req: req,
+            res: res,
+            err: err,
+            latency: latency,
+            secure: req.secure,
+            _audit: true
+        };
+
+        log.info(obj, 'handled: %d', res.statusCode);
+
+        return (true);
+    }
+
+    return (audit);
+}
+
+
+///-- Exports
+
+module.exports = auditLogger;

--- a/lib/common.js
+++ b/lib/common.js
@@ -18,6 +18,7 @@ var sprintf = require('sprintf').sprintf;
 var vasync = require('vasync');
 
 var errors = require('./errors');
+var auditLogger = require('./audit-logger');
 
 var LABELTAG_PREFIX = 'docker:label:';
 var SERVER_VERSION = '1.19';
@@ -255,15 +256,21 @@ function pollJob(client, job_uuid, cb) {
  * because their response bodies can be too big in many cases
  */
 function filteredAuditLog(req, res, route, err) {
-    restify.auditLogger({
+    var logResponseBody = true;
+
+    // Successful GET res bodies are uninteresting and *big*.
+    if ((req.method === 'GET') && Math.floor(res.statusCode/100) === 2)
+        logResponseBody = false;
+
+    auditLogger({
         log: req.log.child({
             component: 'audit',
             route: route && route.name
         }, true),
 
-        // Successful GET res bodies are uninteresting and *big*.
-        body: !((req.method === 'GET')
-            && Math.floor(res.statusCode/100) === 2)
+        responseBody: {
+            log: logResponseBody
+        }
     })(req, res, route, err);
 }
 


### PR DESCRIPTION
This change prevents logging the body of a given request if its size is
superior to a given constant.

This prevents some of the out of memory crashes that are due to
stringifying large requests' bodies before logging them.