### PR TITLE
DOCKER-467: create config settings for server and api version

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,8 @@ and officially supported version.
 Devs: When updating the sdc-docker server official version, you'll need to
 be sure to update the following:
 
-1. update SERVER_VERSION version in lib/common.js
-2. update the test client version in test/integration/helpers.js
-3. update the docker cli test client version in
+1. update both *API_VERSION* and *SERVER_VERSION* version in lib/constants.js
+2. update the docker cli test client version in
    globe-theatre/bin/nightly-test-docker-integration-cli
 
 

--- a/lib/backends/sdc/utils.js
+++ b/lib/backends/sdc/utils.js
@@ -13,6 +13,7 @@ var net = require('net');
 var restify = require('restify');
 
 var common = require('../../common');
+var constants = require('../../constants');
 var Link = require('../../models/link');
 
 
@@ -678,7 +679,7 @@ function imgobjToInspect(obj) {
         Container: '', // which container?
         ContainerConfig: image.container_config,
         Created: new Date(image.created),
-        DockerVersion: common.SERVER_VERSION,
+        DockerVersion: constants.SERVER_VERSION,
         Id: image.docker_id,
         Os: 'Joyent Smart Data Center',
         Parent: image.parent,

--- a/lib/common.js
+++ b/lib/common.js
@@ -17,11 +17,11 @@ var sprintf = require('sprintf').sprintf;
 var url = require('url');
 var vasync = require('vasync');
 
+var constants = require('./constants');
 var errors = require('./errors');
 var auditLogger = require('./audit-logger');
 
 var LABELTAG_PREFIX = 'docker:label:';
-var SERVER_VERSION = '1.19';
 
 
 
@@ -339,24 +339,42 @@ function reqClientApiVersion(req, res, next) {
     if (!apiversion) {
         // It's okay if the api version is missing, we just default to using the
         // current server version in that case.
-        apiversion = '/v' + SERVER_VERSION;
+        apiversion = '/v' + constants.API_VERSION;
     }
 
     if (apiversion.match(/^\/v[0-9\.]+$/)) {
-        apiversion = Number(apiversion.slice(2));
-        if ((apiversion !== NaN) && (apiversion >= 1.15)) {
-            log.trace({apiversion: apiversion}, 'request has ok API version');
-            req.clientApiVersion = apiversion;
-            return next();
+        apiversion = apiversion.slice(2);
+
+        if (constants.MIN_API_VERSION
+            && apiversion < constants.MIN_API_VERSION)
+        {
+            return next(new restify.InvalidVersionError(
+                'client API version (' + apiversion
+                + ') is less than the minimum required API version ('
+                + constants.MIN_API_VERSION + ')'));
         }
+
+        if (constants.MAX_API_VERSION
+            && apiversion > constants.MAX_API_VERSION)
+        {
+            return next(new restify.InvalidVersionError(
+                'client API version (' + apiversion
+                + ') is greater than the maximum allowed API version ('
+                + constants.MAX_API_VERSION + ')'));
+        }
+
+        log.trace({apiversion: apiversion}, 'request has ok API version');
+        req.clientApiVersion = Number(apiversion);
+        return next();
     }
 
     log.warn({apiversion: apiversion, req: req},
         'request has invalid API version');
 
     return next(new restify.InvalidVersionError(
-        'client and server don\'t have same version '
-        + '(client : ' + apiversion + ', server: ' + SERVER_VERSION + ')'));
+        'client and server don\'t have same API version '
+        + '(client : ' + apiversion + ', server: '
+        + constants.API_VERSION + ')'));
 }
 
 
@@ -631,6 +649,5 @@ module.exports = {
     waitForJob: waitForJob,
     writeProgress: writeProgress,
     writeStatus: writeStatus,
-    LABELTAG_PREFIX: LABELTAG_PREFIX,
-    SERVER_VERSION: SERVER_VERSION
+    LABELTAG_PREFIX: LABELTAG_PREFIX
 };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,20 @@
+module.exports = {
+
+    // The docker server version reported for 'docker version'.
+    SERVER_VERSION: '1.7.0',
+
+    // The docker remote API version reported for 'docker version', and also
+    // the default API version assumed when a client does not specify a version.
+    API_VERSION: '1.19',
+
+    // The minimum remote API version supported - clients using a version less
+    // than this will be rejected. Can be null, which means there is no
+    // minimum version.
+    MIN_API_VERSION: '1.15',
+
+    // The maximum remote API version supported - clients using a version
+    // greater than this will be rejected. Can be null, which means there is
+    // no maximum version.
+    MAX_API_VERSION: null
+
+};

--- a/lib/endpoints/version.js
+++ b/lib/endpoints/version.js
@@ -14,6 +14,7 @@ var restify = require('restify');
 var errors = require('../errors');
 
 var common = require('../common');
+var constants = require('../constants');
 
 
 var dockerArchFromArch = {
@@ -51,14 +52,14 @@ function version(req, res, next) {
     }
     buildInfo = require(path.resolve(__dirname, '../../etc/build.json'));
     var v = {
-        'ApiVersion': common.SERVER_VERSION.toString(),
+        'ApiVersion': constants.API_VERSION,
         'Arch': dockerArch,
         'GitCommit': buildInfo.commit,
         'GoVersion': 'node' + process.version.slice(1),
         // XXX shell out to `uname` for this? Then *cache* that.
         //  'KernelVersion': '3.13.0-36-generic',
         'Os': dockerOs,
-        'Version': req.app.version
+        'Version': constants.SERVER_VERSION
     };
     res.send(v);
     next();

--- a/test/integration/api-create.test.js
+++ b/test/integration/api-create.test.js
@@ -191,7 +191,8 @@ test('api: create', function (tt) {
             vmapiClient: VMAPI,
             dockerClient: DOCKER_ALICE,
             test: t,
-            extra: { 'Memory': memory }
+            extra: { 'Memory': memory },
+            apiVersion: 'v1.17'
         }, oncreate);
 
         function oncreate(err, result) {
@@ -218,7 +219,8 @@ test('api: create', function (tt) {
             vmapiClient: VMAPI,
             dockerClient: DOCKER_ALICE,
             test: t,
-            extra: { 'Memory': 'Foo' }
+            extra: { 'Memory': 'Foo' },
+            apiVersion: 'v1.17'
         }, oncreate);
 
         function oncreate(err, result) {

--- a/test/integration/apiversion.test.js
+++ b/test/integration/apiversion.test.js
@@ -12,11 +12,9 @@
  * Integration tests for docker client version handling.
  */
 
-var common = require('../../lib/common');
-var cli = require('../lib/cli');
+var constants = require('../../lib/constants');
 var h = require('./helpers');
 var test = require('tape');
-var vasync = require('vasync');
 
 
 
@@ -57,7 +55,7 @@ test('apiversion', function (tt) {
         var infoPath = verPrefix + '/info';
         var containersPath = verPrefix + '/containers/json';
         var imagesPath = verPrefix + '/images/json';
-        var pingPath = verPrefix + '/_ping';
+        var versionPath = verPrefix + '/version';
 
         tt.test('apiversion ' + infoPath, function (t) {
             // docker info
@@ -104,26 +102,27 @@ test('apiversion', function (tt) {
             });
         });
 
-        tt.test('apiversion ' + pingPath, function (t) {
-            // docker ping
-            DOCKER_ALICE.get(pingPath,
-                    function (err, req, res, ping) {
+        tt.test('apiversion ' + versionPath, function (t) {
+            // docker version
+            DOCKER_ALICE.get(versionPath,
+                    function (err, req, res, verInfo) {
                 if (opts && opts.shouldFail) {
                     t.ok(err, 'expected request to fail');
                     t.end();
                     return;
                 }
-                t.ifError(err, 'apiversion ' + pingPath);
-                t.ok(ping, 'ping response');
+                t.ifError(err, 'apiversion ' + versionPath);
+                t.ok(verInfo, 'version response');
                 t.end();
             });
         });
     }
 
     testVersionHandling();        // no version
-    testVersionHandling('v1.15'); // old version
-    testVersionHandling('v' + common.SERVER_VERSION); // current server version
+    testVersionHandling('v1.14', { shouldFail: true }); // unsupported version
+    testVersionHandling('v' + constants.MIN_API_VERSION); // min ver
+    testVersionHandling('v' + constants.API_VERSION); // current ver
     testVersionHandling('v9.99'); // future version
-    testVersionHandling('1.15', { shouldFail: true });   // invalid version
+    testVersionHandling('1.14', { shouldFail: true });   // invalid version
     testVersionHandling('golden', { shouldFail: true }); // invalid version
 });

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -24,6 +24,7 @@ var vasync = require('vasync');
 
 var common = require('../lib/common');
 var sdcCommon = require('../../lib/common');
+var constants = require('../../lib/constants');
 
 
 // --- globals
@@ -36,6 +37,7 @@ var CONFIG = {
 var p = console.error;
 var UA = 'sdcdockertest';
 
+var dockerVersion = constants.SERVER_VERSION;
 
 var CLIENT_ZONE_PAYLOAD = {
     'alias': 'sdcdockertest_client',
@@ -58,6 +60,7 @@ var CLIENT_ZONE_PAYLOAD = {
         'user-script': [
             '#!/bin/bash',
             '',
+            'DOCKER_VERSION="' + dockerVersion + '"',
             'if [[ ! -d /root/bin ]]; then',
             '    mkdir -p /root/bin',
             '    echo \'export PATH=/root/bin:$PATH\' >>/root/.profile',
@@ -69,13 +72,12 @@ var CLIENT_ZONE_PAYLOAD = {
             '    curl -sSO https://raw.githubusercontent.com/joyent/sdc-docker/master/tools/sdc-docker-setup.sh',
             '    chmod +x sdc-docker-setup.sh',
             'fi',
-            'if [[ ! -x docker-1.7.0 ]]; then',
-            '    curl -sSO https://us-east.manta.joyent.com/trent.mick/public/all-the-dockers/docker-1.7.0',
-            '    chmod +x docker-1.7.0',
+            'if [[ ! -x docker-${DOCKER_VERSION} ]]; then',
+            '    curl -sSO https://us-east.manta.joyent.com/trent.mick/public/all-the-dockers/docker-${DOCKER_VERSION}',
+            '    chmod +x docker-${DOCKER_VERSION}',
             'fi',
-            'if [[ ! -f docker ]]; then',
-            '    ln -s docker-1.7.0 docker',
-            'fi',
+            'rm -f docker',
+            'ln -s docker-${DOCKER_VERSION} docker',
             '',
             'touch /var/svc/user-script-done  # see waitForClientZoneUserScript'
         ].join('\n')
@@ -1233,7 +1235,7 @@ function createDockerContainer(opts, callback) {
     var t = opts.test;
     var log = dockerClient.log;
     var response = {};
-    var apiVersion = opts.apiVersion || 'v1.16';
+    var apiVersion = opts.apiVersion || ('v' + constants.API_VERSION);
 
     if (opts.extra) {
         for (var e in opts.extra) {


### PR DESCRIPTION
Summary of changes:
* new *etc/defaults.json* file
  * not sure why another config file - why not use the sapi manifest file?
* docker server API version (1.19) and docker server version (1.7) moved to *etc/defaults.json* file
* sdc-docker app config first loads the default config (*etc/defaults.json*), then loads the sapi config (*etc/config.json*) and then merges these two config settings (sapi wins over default) to create the app.config
* update various places/tests where server/api version is used