### PR TITLE
DOCKER-697 add support for filtering on label w/ docker 1.10

### DIFF
--- a/lib/backends/sdc/containers.js
+++ b/lib/backends/sdc/containers.js
@@ -2265,25 +2265,29 @@ function getContainersForVms(opts, callback) {
 function getLabelFilters(opts, filters) {
     assert.object(opts, 'opts');
     assert.number(opts.apiVersion, 'opts.apiVersion');
-    assert.optionalObject(opts.log, 'opts.log');
+    assert.object(opts.log, 'opts.log');
     assert.object(filters, 'filters');
 
-    var log = opts.log || this.log;
+    var log = opts.log;
     var val = filters;
 
-    if (opts.apiVersion >= 1.22 && !Array.isArray(val)) {
+    if ((common.apiVersionCmp(opts.apiVersion, 1.22) >= 0)
+        && !Array.isArray(val)) {
+        // the version is >= 1.22 and we got a non array object, convert to
+        // array based on keys.
         val = Object.keys(val);
     }
 
     // val should have either been an array, or we should have turned it into
-    // one. Any other one is an unexpected case we need to add to the code.
+    // one. Any other value is illegal.
     if (!Array.isArray(val)) {
         log.warn({
             filters: filters,
             type: typeof (val),
             val: JSON.stringify(val)
         }, 'WARNING: filter value is not an array');
-        return ([]);
+
+        return new Error('invalid filter');
     }
 
     return (val);
@@ -2380,6 +2384,7 @@ function getContainers(opts, callback) {
             var filters;
             var filteringOnPkgs = false;
             var i;
+            var invalidFilter;
             var invalidPackageName;
             var labelFilters;
             var labelSplit;
@@ -2394,6 +2399,10 @@ function getContainers(opts, callback) {
                     log: log
                 }, filters['label']);
 
+                if (labelFilters instanceof Error) {
+                    invalidFilter = true;
+                }
+
                 for (i = 0; i < labelFilters.length; i++) {
                     labelSplit = labelFilters[i].split('=', 2);
                     if (labelSplit[0] === PACKAGE_SELECTION_LABEL) {
@@ -2405,6 +2414,11 @@ function getContainers(opts, callback) {
                         }
                     }
                 }
+            }
+
+            if (invalidFilter) {
+                cb(new errors.DockerError('invalid filters specified'));
+                return;
             }
 
             if (invalidPackageName) {
@@ -2525,6 +2539,12 @@ function getContainers(opts, callback) {
                         apiVersion: opts.clientApiVersion,
                         log: log
                     }, filters[field]);
+
+                    // _preloadPackages should already have validated, so we
+                    // just make sure here we don't get an error. If we do, this
+                    // is a programmer error.
+                    assert.ok(!(labelFilters instanceof Error),
+                        'getLabelFilters should not error');
 
                     // labelFilters is an *array* of acceptable docker name's
                     // *strings*, so find any containers matching *all* of the

--- a/lib/backends/sdc/containers.js
+++ b/lib/backends/sdc/containers.js
@@ -2246,6 +2246,49 @@ function getContainersForVms(opts, callback) {
     });
 }
 
+/*
+ * With Docker 1.10 (API version 1.22) the filters changed from an array to an
+ * object with the value true.
+ *
+ * In 1.9.1:
+ *
+ *     filters={"label":["com.joyent.package=sample-2G"]}
+ *
+ * In 1.10.0:
+ *
+ *     filters={"label":{"com.joyent.package=sample-2G":true}}
+ *
+ * This function takes the filters[label] value (as the filters parameter here)
+ * and returns a normalized array of the packages we want to filter on.
+ *
+ */
+function getLabelFilters(opts, filters) {
+    assert.object(opts, 'opts');
+    assert.number(opts.apiVersion, 'opts.apiVersion');
+    assert.optionalObject(opts.log, 'opts.log');
+    assert.object(filters, 'filters');
+
+    var log = opts.log || this.log;
+    var val = filters;
+
+    if (opts.apiVersion >= 1.22 && !Array.isArray(val)) {
+        val = Object.keys(val);
+    }
+
+    // val should have either been an array, or we should have turned it into
+    // one. Any other one is an unexpected case we need to add to the code.
+    if (!Array.isArray(val)) {
+        log.warn({
+            filters: filters,
+            type: typeof (val),
+            val: JSON.stringify(val)
+        }, 'WARNING: filter value is not an array');
+        return ([]);
+    }
+
+    return (val);
+}
+
 function getContainers(opts, callback) {
     assert.object(opts, 'opts');
     assert.object(opts.account, 'opts.account');
@@ -2336,32 +2379,32 @@ function getContainers(opts, callback) {
         }, function _preloadPackages(stash, cb) {
             var filters;
             var filteringOnPkgs = false;
-            var filterKeys;
+            var i;
             var invalidPackageName;
+            var labelFilters;
+            var labelSplit;
 
             if (opts.filters) {
                 filters = JSON.parse(opts.filters);
-                filterKeys = Object.keys(filters);
             }
 
-            if (filters && filterKeys.indexOf('label') !== -1) {
-                filterKeys.forEach(function _findPkgSelectLabel(field) {
-                    var i;
-                    var labelSplit;
-                    var val = filters[field];
+            if (filters && Object.keys(filters).indexOf('label') !== -1) {
+                labelFilters = getLabelFilters({
+                    apiVersion: opts.clientApiVersion,
+                    log: log
+                }, filters['label']);
 
-                    for (i = 0; i < val.length; i++) {
-                        labelSplit = val[i].split('=', 2);
-                        if (labelSplit[0] === PACKAGE_SELECTION_LABEL) {
-                            filteringOnPkgs = true;
-                            if (labelSplit[1].match(BAD_PKG_NAME_RE)
-                                || !labelSplit[1].match(PKG_NAME_RE)) {
-                                // invalid package name, this is an error
-                                invalidPackageName = labelSplit[1];
-                            }
+                for (i = 0; i < labelFilters.length; i++) {
+                    labelSplit = labelFilters[i].split('=', 2);
+                    if (labelSplit[0] === PACKAGE_SELECTION_LABEL) {
+                        filteringOnPkgs = true;
+                        if (labelSplit[1].match(BAD_PKG_NAME_RE)
+                            || !labelSplit[1].match(PKG_NAME_RE)) {
+                            // invalid package name, this is an error
+                            invalidPackageName = labelSplit[1];
                         }
                     }
-                });
+                }
             }
 
             if (invalidPackageName) {
@@ -2416,6 +2459,7 @@ function getContainers(opts, callback) {
 
             filters = JSON.parse(opts.filters);
             Object.keys(filters).forEach(function _filterField(field) {
+                var labelFilters;
                 var val = filters[field];
                 var val_to_sdc_status;
 
@@ -2477,14 +2521,19 @@ function getContainers(opts, callback) {
                         return false;
                     });
                 } else if (field == 'label') {
-                    // val is an *array* of acceptable docker name's
-                    // *strings*, so find any containers matching
-                    // *all* of the requested values.
-                    for (var j = 0; j < val.length; j++) {
+                    labelFilters = getLabelFilters({
+                        apiVersion: opts.clientApiVersion,
+                        log: log
+                    }, filters[field]);
+
+                    // labelFilters is an *array* of acceptable docker name's
+                    // *strings*, so find any containers matching *all* of the
+                    // requested values.
+                    for (var j = 0; j < labelFilters.length; j++) {
                         // val[i] is either 'key' or 'key=value'
                         var labelK; // key
                         var labelV; // value
-                        var labelSplit = val[j].split('=', 2);
+                        var labelSplit = labelFilters[j].split('=', 2);
                         var wantedTag = common.LABELTAG_PREFIX
                             + labelSplit[0];
 

--- a/lib/common.js
+++ b/lib/common.js
@@ -753,9 +753,72 @@ function httpClientOpts(clientOpts, req) {
     return clientOpts;
 }
 
+/*
+ * Values can be a number (1.22) or a string ("1.22")
+ *
+ * Returns:
+ *
+ *  >=1  if a > b
+ *    0  if a == b
+ *  <=1  if a < b
+ *
+ * Thus you can use:
+ *
+ *  (apiVersionCmp(a, b) > 0)  // ensure a > b
+ *  (apiVersionCmp(a, b) >= 0) // ensure a >= b
+ *  (apiVersionCmp(a, b) < 0)  // ensure a < b
+ *
+ */
+function apiVersionCmp(A, B)
+{
+    var a = A;
+    var aMatch;
+    var b = B;
+    var bMatch;
+    var re = /^([0-9]+)\.([0-9]+)$/;
 
+    if (typeof (a) === 'number') {
+        if ((a % 1) !== 0) {
+            // we have a 1.xxx
+            a = a.toString();
+        } else {
+            // we have 1
+            a = a.toFixed(1);
+        }
+    }
+    if (typeof (b) === 'number') {
+        if ((b % 1) !== 0) {
+            b = b.toString();
+        } else {
+            b = b.toFixed(1);
+        }
+    }
+
+    assert.string(a, 'a');
+    assert.string(b, 'b');
+
+    aMatch = a.match(re);
+    bMatch = b.match(re);
+
+    assert.ok(aMatch, 'a must match ' + re.toString());
+    assert.ok(bMatch, 'b must match ' + re.toString());
+
+    // They match!
+    if (a === b) {
+        return (0);
+    }
+
+    // compare major versions
+    if (Number(aMatch[1]) !== Number(bMatch[1])) {
+        return (Number(aMatch[1]) - Number(bMatch[1]));
+    }
+
+    // compare minor versions
+    return (Number(aMatch[2]) - Number(bMatch[2]));
+}
 
 module.exports = {
+    apiVersionCmp: apiVersionCmp,
     reqClientApiVersion: reqClientApiVersion,
     httpClientOpts: httpClientOpts,
     checkApprovedForProvisioning: checkApprovedForProvisioning,

--- a/test/unit/common.test.js
+++ b/test/unit/common.test.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2014, Joyent, Inc.
+ * Copyright (c) 2016, Joyent, Inc.
  */
 
 /*
@@ -89,6 +89,40 @@ test('boolFromQueryParam', function (t) {
     t.equal(boolFromQueryParam('nope'), true);
     t.equal(boolFromQueryParam('nein'), true);
     t.equal(boolFromQueryParam('nyet'), true);
+
+    t.end();
+});
+
+
+test('apiVersionCmp', function (t) {
+    var apiVersionCmp = common.apiVersionCmp;
+
+    t.equal(apiVersionCmp('1.22', 1.22), 0, '"1.22" == 1.22');
+    t.equal(apiVersionCmp(1.21, 1.22), -1, '1.21 < 1.22');
+    t.equal(apiVersionCmp('1.23', '1.22'), 1, '"1.23" > "1.22"');
+    t.equal(apiVersionCmp('2.0', '1.0'), 1, '"2.0" > "1.0"');
+    t.equal(apiVersionCmp(1.0, 2.0), -1, '"1.0" < "2.0"');
+    t.equal(apiVersionCmp(1, 2), -1, '1 < 2');
+    t.equal(apiVersionCmp(2, '2.0'), 0, '2 == "2.0"');
+    t.equal(apiVersionCmp(2, '1.0'), 1, '2 > "1.0"');
+    t.throws(function () {
+        apiVersionCmp(-42, 42);
+    }, /a must match/, 'negative numbers throw');
+    t.throws(function () {
+        apiVersionCmp(undefined, 1.22);
+    }, /a \(string\) is required/, 'undefined throws');
+    t.throws(function () {
+        apiVersionCmp(null, 1.22);
+    }, /a \(string\) is required/, 'null throws');
+    t.throws(function () {
+        apiVersionCmp({hello: 'world'}, 1.22);
+    }, /a \(string\) is required/, 'object throws');
+    t.throws(function () {
+        apiVersionCmp({}, 1.22);
+    }, /a \(string\) is required/, 'empty object throws');
+    t.throws(function () {
+        apiVersionCmp([], 1.22);
+    }, /a \(string\) is required/, 'empty array throws');
 
     t.end();
 });

--- a/test/unit/common.test.js
+++ b/test/unit/common.test.js
@@ -99,6 +99,7 @@ test('apiVersionCmp', function (t) {
 
     t.equal(apiVersionCmp('1.22', 1.22), 0, '"1.22" == 1.22');
     t.equal(apiVersionCmp(1.21, 1.22), -1, '1.21 < 1.22');
+    t.equal(apiVersionCmp(1.9, 1.22), -13, '"1.9" < 1.22');
     t.equal(apiVersionCmp('1.23', '1.22'), 1, '"1.23" > "1.22"');
     t.equal(apiVersionCmp('2.0', '1.0'), 1, '"2.0" > "1.0"');
     t.equal(apiVersionCmp(1.0, 2.0), -1, '"1.0" < "2.0"');


### PR DESCRIPTION
With docker 1.10 they changed the data sent with the command:

```
docker ps --filter "label=com.joyent.package=sample-1G" --format '{{.ID}} {{.Label "com.joyent.package"}}'
```

such that instead of an array, we get an object. This PR fixes so that we work with both forms.