### PR TITLE
DOCKER-735: queryParser handlers missing for some endpoints that require the query string to be parsed

### DIFF
--- a/lib/backends/sdc/containers.js
+++ b/lib/backends/sdc/containers.js
@@ -32,6 +32,7 @@ var common = require('../../../lib/common');
 var errors = require('../../../lib/errors');
 var images = require('./images');
 var Link = require('../../models/link');
+var signals = require('../../signals');
 var utils = require('./utils');
 var validate = require('../../validate');
 
@@ -2824,7 +2825,7 @@ function killContainer(opts, callback) {
         opts.signal = 'SIGKILL';
     }
 
-    killParams.signal = opts.signal;
+    killParams.signal = signals.convertLinuxToSmartOSSignal(opts.signal);
 
     log.debug('killParams: ' + JSON.stringify(killParams));
     killParams.log = log;

--- a/lib/backends/sdc/containers.js
+++ b/lib/backends/sdc/containers.js
@@ -2824,14 +2824,7 @@ function killContainer(opts, callback) {
         opts.signal = 'SIGKILL';
     }
 
-    if ((typeof (opts.signal) === 'string')
-        && (opts.signal.match(/^[0-9]+$/))) {
-
-        // An integer signal being sent as a string. Fix it.
-        killParams.signal = Number(opts.signal);
-    } else {
-        killParams.signal = opts.signal;
-    }
+    killParams.signal = opts.signal;
 
     log.debug('killParams: ' + JSON.stringify(killParams));
     killParams.log = log;

--- a/lib/endpoints/containers.js
+++ b/lib/endpoints/containers.js
@@ -415,29 +415,16 @@ function containerStart(req, res, next) {
 function containerStop(req, res, next) {
     var log = req.log;
     var t;
-    var tErr;
 
     assert.object(req, 'req');
     assert.object(req.query, 'req.query');
     assert.object(res, 'res');
     assert.func(next, 'next');
 
-    if (req.query.hasOwnProperty('t')) {
-        t = Number(req.query.t);
-        if (isNaN(t) || (req.query.t && req.query.t.length === 0)) {
-            tErr = new errors.ValidationError('stop timeout parameter must be '
-                + 'an integer');
-            log.error({err: tErr, t: t}, 'timeout parameter is not an integer');
-            next(tErr);
-            return;
-        }
-    } else {
+    t = req.query.t;
+    if (t === undefined) {
         t = 10;
     }
-
-    // Docker allows negative values and so will we. In case of negative,
-    // it assumes we should wait forever.
-    t = Math.floor(t);
 
     req.backend.stopContainer({
         account: req.account,
@@ -463,11 +450,19 @@ function containerStop(req, res, next) {
  * POST /containers/:id/restart
  */
 function containerRestart(req, res, next) {
-    var log = req.log;
-    var t = req.query.t;
+    var log;
+    var t;
+
+    assert.object(req, 'req');
+    assert.object(req.query, 'req.query');
+    assert.object(res, 'res');
+    assert.func(next, 'next');
+
+    log = req.log;
+    t = req.query.t;
 
     // default in docker daemon is 10s
-    if (isNaN(t)) {
+    if (t === undefined) {
         t = 10;
     }
 
@@ -495,8 +490,16 @@ function containerRestart(req, res, next) {
  * POST /containers/:id/kill
  */
 function containerKill(req, res, next) {
-    var log = req.log;
-    var signal = req.query.signal;
+    var log;
+    var signal;
+
+    assert.object(req, 'req');
+    assert.object(req.query, 'req.query');
+    assert.object(res, 'res');
+    assert.func(next, 'next');
+
+    log = req.log;
+    signal = req.query.signal;
 
     req.backend.killContainer({
         account: req.account,
@@ -1009,16 +1012,20 @@ function register(http, before) {
     // Match: '/:apiversion/containers/:id/stop'
     http.post({ path: /^(\/v[^\/]+)?\/containers\/([^\/]+)\/stop$/,
         name: 'ContainerStop' }, before, reqParamsId, getVm,
-        restify.queryParser({mapParams: false}), containerStop);
+        restify.queryParser({mapParams: false}), validate.containerStop,
+        containerStop);
 
     // Match: '/:apiversion/containers/:id/restart'
     http.post({ path: /^(\/v[^\/]+)?\/containers\/([^\/]+)\/restart$/,
         name: 'ContainerRestart' }, before, reqParamsId, getVm,
+        restify.queryParser({mapParams: false}), validate.containerRestart,
         containerRestart);
 
     // Match: '/:apiversion/containers/:id/kill'
     http.post({ path: /^(\/v[^\/]+)?\/containers\/([^\/]+)\/kill$/,
-        name: 'ContainerKill' }, before, reqParamsId, getVm, containerKill);
+        name: 'ContainerKill' }, before, reqParamsId, getVm,
+        restify.queryParser({mapParams: false}), validate.containerKill,
+        containerKill);
 
     // Match: '/:apiversion/containers/:id/pause'
     http.post({ path: /^(\/v[^\/]+)?\/containers\/([^\/]+)\/pause$/,

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -169,6 +169,10 @@ util.inherits(UnauthorizedError, restify.UnauthorizedError);
  * attributes for logging.
  */
 function _DockerBaseError(opts) {
+    if (!(this instanceof arguments.callee)) {
+        assert.ok(false,  arguments.callee.name + ' must be invoked with new');
+    }
+
     assert.object(opts, 'opts');
     RestError.call(this, opts);
     if (opts.cause && opts.cause.body) {
@@ -186,6 +190,11 @@ util.inherits(_DockerBaseError, RestError);
  *      new DockerError(cause, message);
  */
 function DockerError(cause, message) {
+    if (!(this instanceof arguments.callee)) {
+        assert.ok(false,  arguments.callee.name + ' must be invoked with new');
+    }
+
+
     if (message === undefined) {
         message = cause;
         cause = undefined;
@@ -210,6 +219,10 @@ DockerError.description =
  * TODO(trentm): call this just "TimeoutError"?
  */
 function CommandTimeoutError(cause) {
+    if (!(this instanceof arguments.callee)) {
+        assert.ok(false,  arguments.callee.name + ' must be invoked with new');
+    }
+
     assert.object(cause, 'cause');
     _DockerBaseError.call(this, {
         restCode: this.constructor.restCode,
@@ -233,6 +246,10 @@ CommandTimeoutError.description = 'Timed-out waiting for request response.';
  *      `{memory: '65g'}`.
  */
 function NoSufficientPackageError(constraints) {
+    if (!(this instanceof arguments.callee)) {
+        assert.ok(false,  arguments.callee.name + ' must be invoked with new');
+    }
+
     assert.object(constraints, 'constraints');
 
     var msg = 'no package supports the given container constraints: '
@@ -254,6 +271,10 @@ NoSufficientPackageError.description =
 
 
 function NotImplementedError(feature) {
+    if (!(this instanceof arguments.callee)) {
+        assert.ok(false,  arguments.callee.name + ' must be invoked with new');
+    }
+
     _DockerBaseError.call(this, {
         restCode: this.constructor.restCode,
         statusCode: this.constructor.statusCode,
@@ -269,6 +290,10 @@ NotImplementedError.description =
 
 
 function ValidationError(cause, message) {
+    if (!(this instanceof arguments.callee)) {
+        assert.ok(false,  arguments.callee.name + ' must be invoked with new');
+    }
+
     if (message === undefined) {
         message = cause;
         cause = undefined;
@@ -290,6 +315,10 @@ ValidationError.description = 'Invalid request payload';
 
 
 function AmbiguousDockerImageIdError(imgId, registries) {
+    if (!(this instanceof arguments.callee)) {
+        assert.ok(false,  arguments.callee.name + ' must be invoked with new');
+    }
+
     assert.string(imgId, 'imgId');
     assert.arrayOfString(registries, 'registries');
 
@@ -321,6 +350,10 @@ AmbiguousDockerImageIdError.description =
  * to be defensive.
  */
 function ExposedSDCError(cause, message) {
+    if (!(this instanceof arguments.callee)) {
+        assert.ok(false,  arguments.callee.name + ' must be invoked with new');
+    }
+
     assert.object(cause, 'cause');
     assert.string(message, 'message');
     assert.string(cause.restCode, 'cause.restCode');
@@ -365,6 +398,10 @@ util.inherits(ExposedSDCError, _DockerBaseError);
  *      new DockerNoComputeResourcesError(cause);
  */
 function DockerNoComputeResourcesError(cause) {
+    if (!(this instanceof arguments.callee)) {
+        assert.ok(false,  arguments.callee.name + ' must be invoked with new');
+    }
+
     var message = 'No compute resources available.';
     _DockerBaseError.call(this, {
         restCode: this.constructor.restCode,
@@ -391,6 +428,10 @@ DockerNoComputeResourcesError.description = 'No compute resources available.';
  *      new VolumeServerNoResourcesError(cause);
  */
 function VolumeServerNoResourcesError(cause) {
+    if (!(this instanceof arguments.callee)) {
+        assert.ok(false,  arguments.callee.name + ' must be invoked with new');
+    }
+
     var message =
         'No compute resources available on the '
         + 'host containing the mounted volume.';
@@ -419,6 +460,10 @@ VolumeServerNoResourcesError.description =
  *      new ServiceDegradedError(cause);
  */
 function ServiceDegradedError(cause) {
+    if (!(this instanceof arguments.callee)) {
+        assert.ok(false,  arguments.callee.name + ' must be invoked with new');
+    }
+
     var message =
         'service is currently unavailable';
     _DockerBaseError.call(this, {
@@ -438,6 +483,10 @@ ServiceDegradedError.description =
 
 
 function DockerContainerNotRunningError(cause, message) {
+    if (!(this instanceof arguments.callee)) {
+        assert.ok(false,  arguments.callee.name + ' must be invoked with new');
+    }
+
     _DockerBaseError.call(this, {
         restCode: this.constructor.restCode,
         statusCode: (cause && cause.statusCode) || this.constructor.statusCode,
@@ -455,6 +504,10 @@ DockerContainerNotRunningError.description
 
 
 function FileNotFoundError(cause) {
+    if (!(this instanceof arguments.callee)) {
+        assert.ok(false,  arguments.callee.name + ' must be invoked with new');
+    }
+
     var message =
         'no such file or directory';
     _DockerBaseError.call(this, {
@@ -472,6 +525,10 @@ FileNotFoundError.description = 'no such file or directory';
 
 
 function PathNotDirectoryError(cause) {
+    if (!(this instanceof arguments.callee)) {
+        assert.ok(false,  arguments.callee.name + ' must be invoked with new');
+    }
+
     var message =
         'path was not to a directory';
     _DockerBaseError.call(this, {

--- a/lib/signals.js
+++ b/lib/signals.js
@@ -1,0 +1,161 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (c) 2016, Joyent, Inc.
+ */
+
+var assert = require('assert-plus');
+
+// This table is used for several purposes:
+// 1. It defines the list of valid signal numbers and names that can be sent
+//    to a Docker container.
+// 2. It defines a mapping between Linux signal numbers to SmartOS signal names.
+var linuxToSmartOSSigNames = {
+    // Signal 0 is a "special" signal that doesn't trigger any handler: all the
+    // code that checks whether the sender has the permission to send a signal
+    // to the target process are performed though, so it can generally be used
+    // to test permissions without having an impact on the target process. His
+    // symbolic name is '0' too.
+    '0':         '0',
+    'HUP':       'SIGHUP',
+    'INT':       'SIGINT',
+    'QUIT':      'SIGQUIT',
+    'ILL':       'SIGILL',
+    'TRAP':      'SIGTRAP',
+    'ABRT':      'SIGABRT',
+    'BUS':       'SIGBUS',
+    'FPE':       'SIGFPE',
+    'KILL':      'SIGKILL',
+    'USR1':      'SIGUSR1',
+    'SEGV':      'SIGSEGV',
+    'USR2':      'SIGUSR2',
+    'PIPE':      'SIGPIPE',
+    'ALRM':      'SIGALRM',
+    'TERM':      'SIGTERM',
+    // Signal 16 is SIGSTKFLT on Linux, which doesn't exists on SmartOS.
+    // Instead, the SmartOS' lx brand maps it to SIGEMT, which doesn't exist
+    // on Linux, so the mapping for any Linux signal to a SmartOS signal is
+    // still unique.
+    'STKFLT':    'SIGEMT',
+    'CHLD':      'SIGCHLD',
+    'CONT':      'SIGCONT',
+    'STOP':      'SIGSTOP',
+    'TSTP':      'SIGTSTP',
+    'TTIN':      'SIGTTIN',
+    'TTOU':      'SIGTTOU',
+    'URG':       'SIGURG',
+    'XCPU':      'SIGXCPU',
+    'XFSZ':      'SIGXFSZ',
+    'VTALRM':    'SIGVTALRM',
+    'PROF':      'SIGPROF',
+    'WINCH':     'SIGWINCH',
+    'POLL':      'SIGPOLL',
+    'PWR':       'SIGPWR',
+    'SYS':       'SIGSYS'
+};
+
+// linuxSignalNames is just an array of all valid signal names on Linux
+var linuxSignalNames = Object.keys(linuxToSmartOSSigNames);
+
+/**
+ * Returns a string that represents the signal with name "signalName" without
+ * the 'SIG' prefix. For instance, toShortSignalName('SIGKILL') returns 'KILL'.
+ */
+function toShortSignalName(signalName) {
+    assert.string(signalName, 'signalName');
+
+    return signalName.replace(/^SIG/, '');
+}
+
+/**
+ * Returns a string that represents the signal with name "signalName" with the
+ * 'SIG' prefix. For instance, toShortSignalName('KILL') returns 'SIGKILL'.
+ */
+function toLongSignalName(signalName) {
+    assert.string(signalName, 'signalName');
+
+    if (signalName.length > 0
+        && isNaN(Number(signalName))
+        && signalName.indexOf('SIG') !== 0
+        && isValidLinuxSignal(signalName)) {
+        return 'SIG' + signalName;
+    } else {
+        return signalName;
+    }
+}
+
+/*
+ * Converts a signal number or string from a Linux signal to its equivalent
+ * SmartOS signal long name as a string.
+ *
+ * If "signal" represents an invalid Linux signal, it returns undefined.
+ *
+ * Some examples:
+ *
+ *  - convertLinuxToSmartOSSignal('7') returns 'SIGBUS'
+ *  - convertLinuxToSmartOSSignal('BUS') returns 'SIGBUS'.
+ *  - convertLinuxToSmartOSSignal('SIGBUS') returns 'SIGBUS'.
+ *  - convertLinuxToSmartOSSignal(42) returns undefined.
+ *  - convertLinuxToSmartOSSignal('SIGFREEZE') returns undefined.
+ */
+function convertLinuxToSmartOSSignal(signal) {
+    assert.string(signal, 'signal');
+
+    var signalNumber = Number(signal);
+    var linuxSignalName;
+    var smartOSSignalName;
+
+    if (isNaN(signalNumber)) {
+        // Symbolic signal names don't need to be mapped to SmartOS signals,
+        // as all signal names that are supported on Linux _and_ SmartOS have
+        // the same semantics, e.g SIGBUS on Linux has the same semantics as
+        // SIGBUS on SmartOS, even if they don't correspond to the same signal
+        // numbers.
+        smartOSSignalName = linuxToSmartOSSigNames[toShortSignalName(signal)];
+    } else if (signal.length > 0) {
+        // Numeric signals don't have the same semantics on Linux and SmartOS.
+        // For instance, signal 7 means SIGBUS on Linux whereas it means
+        // SIGEMT on SmartOS. Thus, when a user means to send signal 7 to her
+        // Docker container, she means `SIGBUS`, and thus the kill task run by
+        // cn-agent needs to send SIGBUS from the global zone to that
+        // container's init process, _not_ signal 7.
+        linuxSignalName = linuxSignalNames[signalNumber];
+        smartOSSignalName = linuxToSmartOSSigNames[linuxSignalName];
+    }
+
+    return smartOSSignalName;
+}
+
+/**
+ * Returns true if "signal" is a string that represents a valid Linux signal,
+ * false otherwise.
+ * For instance, isValidLinuxSignal('SIGKILL') returns true, but
+ * isValidLinuxSignal('SIGFREEZE') returns false.
+ */
+function isValidLinuxSignal(signal) {
+    assert.string(signal, 'signal');
+
+    var signalNumber = Number(signal);
+
+    if (isNaN(signalNumber)) {
+        return linuxSignalNames.indexOf(toShortSignalName(signal)) !== -1;
+    } else {
+        // Check signal is not empty string, which coerces to 0,
+        // and that it's within the range of valid linux signals.
+        return signal.length > 0
+            && signalNumber >= 0 && signalNumber < linuxSignalNames.length
+            && linuxSignalNames[signalNumber] !== undefined;
+    }
+}
+
+module.exports = {
+    convertLinuxToSmartOSSignal: convertLinuxToSmartOSSignal,
+    isValidLinuxSignal: isValidLinuxSignal,
+    linuxSignalNames: linuxSignalNames,
+    toShortSignalName: toShortSignalName,
+    toLongSignalName: toLongSignalName
+};

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -431,7 +431,147 @@ function validateArchiveWriteStream(req, res, next) {
     next();
 }
 
+/*
+ * Validates that the query string parameter "paramName" is a valid signal,
+ * and calls "callback" with an error parameter and the validated value. For
+ * consistency, the validated value is always a string, even if the signal is
+ * represented by a number.
+ */
+function validateSignal(req, paramName, callback) {
+    assert.object(req, 'req');
+    assert.object(req.query, 'req.query');
+    assert.string(paramName, 'paramName');
+    assert.func(callback, 'callback');
 
+    var signalString;
+    var validSignal = false;
+    var err;
+
+    // XXX This includes all signals from process.binding('constants') plus
+    // the special '0' signal. Anything not on this list is not supported by
+    // the backend, but it's possible we'll want to remove some from this list
+    // too as some of these probably don't make sense to send.
+    var validSignals = [
+        'SIGABRT', 'SIGALRM', 'SIGBUS', 'SIGCHLD', 'SIGCONT', 'SIGFPE',
+        'SIGHUP', 'SIGILL', 'SIGINT', 'SIGIO', 'SIGIOT', 'SIGKILL', 'SIGLOST',
+        'SIGPIPE', 'SIGPOLL', 'SIGPROF', 'SIGPWR', 'SIGQUIT', 'SIGSEGV',
+        'SIGSTOP', 'SIGSYS', 'SIGTERM', 'SIGTRAP', 'SIGTSTP', 'SIGTTIN',
+        'SIGTTOU', 'SIGURG', 'SIGUSR1', 'SIGUSR2', 'SIGVTALRM', 'SIGWINCH',
+        'SIGXCPU', 'SIGXFSZ', 'ABRT', 'ALRM', 'BUS', 'CHLD', 'CONT', 'FPE',
+        'HUP', 'ILL', 'INT', 'IO', 'IOT', 'KILL', 'LOST', 'PIPE', 'POLL',
+        'PROF', 'PWR', 'QUIT', 'SEGV', 'STOP', 'SYS', 'TERM', 'TRAP', 'TSTP',
+        'TTIN', 'TTOU', 'URG', 'USR1', 'USR2', 'VTALRM', 'WINCH', 'XCPU',
+        'XFSZ', '0', '1', '2', '3', '4', '5', '6', '6', '8', '9', '10', '11',
+        '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '22',
+        '23', '24', '25', '26', '27', '28', '29', '30', '31', '37'
+    ];
+
+    if (req.query.hasOwnProperty(paramName)) {
+        signalString = req.query[paramName];
+        validSignal = validSignals.indexOf(signalString) !== -1;
+
+        if (!validSignal) {
+            err = 'Invalid parameter "' + paramName + '": '
+                + JSON.stringify(signalString) + ' is not a valid signal';
+        }
+    }
+
+    return callback(err, signalString);
+}
+
+/*
+ * Validates that the query string parameter "paramName" is a valid timeout
+ * value, and calls "callback" with an error parameter and the validated
+ * value. The resulting timeout value is rounded down to the nearest integer
+ * value.
+ */
+function validateTimeout(req, paramName, callback) {
+    assert.object(req, 'req');
+    assert.object(req.query, 'req.query');
+    assert.string(paramName, 'paramName');
+    assert.func(callback, 'callback');
+
+    var timeoutString;
+    var timeoutValue;
+
+    if (req.query.hasOwnProperty(paramName)) {
+        timeoutString = req.query[paramName];
+        timeoutValue = Number(timeoutString);
+
+        if (typeof (timeoutString) === 'string' && timeoutString.length === 0
+            || isNaN(timeoutValue)) {
+            return callback('Invalid parameter "' + paramName + '": '
+                + JSON.stringify(timeoutString)
+                + ' does not represent a number');
+        }
+    }
+
+    // Docker allows negative values and so will we. In case of negative,
+    // it assumes we should wait forever.
+    if (timeoutValue !== undefined) {
+        timeoutValue = Math.floor(timeoutValue);
+    }
+
+    return callback(null, timeoutValue);
+}
+
+function validateContainerKill(req, res, next) {
+    var validationErrors = [];
+
+    validateSignal(req, 'signal', function onSignalValidated(err, signal) {
+        if (err) {
+            validationErrors.push(err);
+        } else {
+            req.query.signal = signal;
+        }
+    });
+
+    if (validationErrors.length > 0) {
+        return next(new errors.ValidationError('Invalid parameters: '
+            + validationErrors.join(', ')));
+    } else {
+        return next();
+    }
+}
+
+function validateContainerRestart(req, res, next) {
+    var validationErrors = [];
+
+    validateTimeout(req, 't', function _onTimeoutValidation(err, timeout) {
+        if (err) {
+            validationErrors.push(err);
+        } else {
+            req.query.t = timeout;
+        }
+    });
+
+    if (validationErrors.length > 0) {
+        return next(new errors.ValidationError('Invalid parameters: '
+            + validationErrors.join(', ')));
+    } else {
+        return next();
+    }
+}
+
+function validateContainerStop(req, res, next) {
+    var validationErrors = [];
+
+    validateTimeout(req, 't', function _onTimeoutValidation(err, timeout) {
+        req.log.info({err: err, timeout: timeout}, 'containerStop validation');
+        if (err) {
+            validationErrors.push(err);
+        } else {
+            req.query.t = timeout;
+        }
+    });
+
+    if (validationErrors.length > 0) {
+        return next(new errors.ValidationError('Invalid parameters: '
+            + validationErrors.join(', ')));
+    } else {
+        return next();
+    }
+}
 
 module.exports = {
     assert: {
@@ -439,5 +579,8 @@ module.exports = {
     },
     createContainer: validateCreateContainer,
     archiveReadStream: validateArchiveReadStream,
-    archiveWriteStream: validateArchiveWriteStream
+    archiveWriteStream: validateArchiveWriteStream,
+    containerRestart: validateContainerRestart,
+    containerKill: validateContainerKill,
+    containerStop: validateContainerStop
 };

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -5,13 +5,15 @@
  */
 
 /*
- * Copyright (c) 2015, Joyent, Inc.
+ * Copyright (c) 2016, Joyent, Inc.
  */
 
 var assert = require('assert-plus');
+var fmt = require('util').format;
+
 var common = require('./common');
 var errors = require('./errors');
-var fmt = require('util').format;
+var signals = require('./signals');
 
 /*
  * This determines how large the Config object passed for a log driver can be
@@ -432,54 +434,6 @@ function validateArchiveWriteStream(req, res, next) {
 }
 
 /*
- * Validates that the query string parameter "paramName" is a valid signal,
- * and calls "callback" with an error parameter and the validated value. For
- * consistency, the validated value is always a string, even if the signal is
- * represented by a number.
- */
-function validateSignal(req, paramName, callback) {
-    assert.object(req, 'req');
-    assert.object(req.query, 'req.query');
-    assert.string(paramName, 'paramName');
-    assert.func(callback, 'callback');
-
-    var signalString;
-    var validSignal = false;
-    var err;
-
-    // XXX This includes all signals from process.binding('constants') plus
-    // the special '0' signal. Anything not on this list is not supported by
-    // the backend, but it's possible we'll want to remove some from this list
-    // too as some of these probably don't make sense to send.
-    var validSignals = [
-        'SIGABRT', 'SIGALRM', 'SIGBUS', 'SIGCHLD', 'SIGCONT', 'SIGFPE',
-        'SIGHUP', 'SIGILL', 'SIGINT', 'SIGIO', 'SIGIOT', 'SIGKILL', 'SIGLOST',
-        'SIGPIPE', 'SIGPOLL', 'SIGPROF', 'SIGPWR', 'SIGQUIT', 'SIGSEGV',
-        'SIGSTOP', 'SIGSYS', 'SIGTERM', 'SIGTRAP', 'SIGTSTP', 'SIGTTIN',
-        'SIGTTOU', 'SIGURG', 'SIGUSR1', 'SIGUSR2', 'SIGVTALRM', 'SIGWINCH',
-        'SIGXCPU', 'SIGXFSZ', 'ABRT', 'ALRM', 'BUS', 'CHLD', 'CONT', 'FPE',
-        'HUP', 'ILL', 'INT', 'IO', 'IOT', 'KILL', 'LOST', 'PIPE', 'POLL',
-        'PROF', 'PWR', 'QUIT', 'SEGV', 'STOP', 'SYS', 'TERM', 'TRAP', 'TSTP',
-        'TTIN', 'TTOU', 'URG', 'USR1', 'USR2', 'VTALRM', 'WINCH', 'XCPU',
-        'XFSZ', '0', '1', '2', '3', '4', '5', '6', '6', '8', '9', '10', '11',
-        '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '22',
-        '23', '24', '25', '26', '27', '28', '29', '30', '31', '37'
-    ];
-
-    if (req.query.hasOwnProperty(paramName)) {
-        signalString = req.query[paramName];
-        validSignal = validSignals.indexOf(signalString) !== -1;
-
-        if (!validSignal) {
-            err = 'Invalid parameter "' + paramName + '": '
-                + JSON.stringify(signalString) + ' is not a valid signal';
-        }
-    }
-
-    return callback(err, signalString);
-}
-
-/*
  * Validates that the query string parameter "paramName" is a valid timeout
  * value, and calls "callback" with an error parameter and the validated
  * value. The resulting timeout value is rounded down to the nearest integer
@@ -515,16 +469,62 @@ function validateTimeout(req, paramName, callback) {
     return callback(null, timeoutValue);
 }
 
+/**
+ * Returns true if "signal" represents a signal that can be sent to a Docker
+ * container, false otherwise.
+ */
+function isValidDockerSignal(signal) {
+    assert.string(signal, 'signal');
+
+    // Docker supports sending any valid Linux signal, except sending signal
+    // '0', so we don't support it too.
+    return signals.isValidLinuxSignal(signal) && signal !== '0';
+}
+
+/**
+ * Returns true if "signal" represents a signal that is not supported by
+ * sdc-docker, false otherwise.
+ */
+function unsupportedSignal(signal) {
+    assert.string(signal, 'signal');
+
+    var UNSUPPORTED_SIGNALS = [
+        // SIGSTKFLT is specific to Linux and doesn't exists on SmartOS.
+        // Instead, the SmartOS' lx brand maps it to SIGEMT, which doesn't exist
+        // on Linux, so the mapping for any Linux signal to a SmartOS signal is
+        // still unique. However, neither SIGSTKFLT or SIGEMT are valid signal
+        // names for node, and because the CNAPI task that sends signals to a
+        // container's init process uses a node program that runs on the compute
+        // node where the container runs, SIGSTKFLT cannot be supported at the
+        // moment.
+        'SIGSTKFLT'
+    ];
+
+    return UNSUPPORTED_SIGNALS.indexOf(signal) !== -1;
+}
+
 function validateContainerKill(req, res, next) {
     var validationErrors = [];
+    var validDockerSignal = false;
+    var signalString = req.query.signal;
 
-    validateSignal(req, 'signal', function onSignalValidated(err, signal) {
-        if (err) {
-            validationErrors.push(err);
-        } else {
-            req.query.signal = signal;
+    if (signalString === '') {
+        // Default emtpy signal is valid
+        return next();
+    }
+
+    validDockerSignal = isValidDockerSignal(signalString);
+    if (!validDockerSignal) {
+        validationErrors.push('Invalid signal: '
+            + JSON.stringify(signalString));
+    }
+
+    if (validationErrors.length === 0) {
+        if (unsupportedSignal(signalString)) {
+            validationErrors.push('signal ' + signalString
+                + ' is not supported');
         }
-    });
+    }
 
     if (validationErrors.length > 0) {
         return next(new errors.ValidationError('Invalid parameters: '

--- a/test/integration/api-start-kill.test.js
+++ b/test/integration/api-start-kill.test.js
@@ -9,7 +9,7 @@
  */
 
 /*
- * Integration tests for docker start and stop using the Remote API directly.
+ * Integration tests for docker start and kill using the Remote API directly.
  */
 
 var test = require('tape');
@@ -125,7 +125,7 @@ test('api: kill', function (tt) {
         function onpost(err, res, req, body) {
             var expectedResponseStatusCode = 422;
             var expectedErrorMessage = '(Validation) Invalid parameters: '
-                + 'Invalid parameter "signal": "foo" is not a valid signal';
+                + 'Invalid signal: "foo"';
 
             t.ok(err, 'Response should be an error');
             t.equal(err.statusCode, expectedResponseStatusCode,
@@ -169,7 +169,7 @@ test('api: kill', function (tt) {
         function onpost(err, res, req, body) {
             var expectedResponseStatusCode = 422;
             var expectedErrorMessage = '(Validation) Invalid parameters: '
-                + 'Invalid parameter "signal": "5000" is not a valid signal';
+                + 'Invalid signal: "5000"';
 
             t.ok(err, 'Response should be an error');
             t.equal(err.statusCode, expectedResponseStatusCode,
@@ -207,147 +207,8 @@ test('api: kill', function (tt) {
         });
     });
 
-
-    tt.test('kill container without specifying a signal', function (t) {
-        DOCKER.post('/containers/' + id + '/kill', onpost);
-        function onpost(err, res, req, body) {
-            t.error(err);
-            t.end(err);
-        }
-    });
-
-
-    tt.test('confirm container killed', function (t) {
-        container.checkContainerStatus(id, /^Exited /, {
-            helper: h,
-            dockerClient: DOCKER,
-            retries: 10
-        }, function _onCheckDone(err, success) {
-            t.ifErr(err, 'Checking container status should not error');
-            t.ok(success, 'Container should be in status exited');
-
-            t.end();
-        });
-    });
-
-    tt.test('restart container', function (t) {
-        DOCKER.post('/containers/' + id + '/restart', onpost);
-        function onpost(err, res, req, body) {
-            t.error(err);
-            t.end(err);
-        }
-    });
-
-
-    tt.test('confirm container restarted', function (t) {
-        h.listContainers({
-            all: true,
-            dockerClient: DOCKER,
-            test: t
-        }, function (err, containers) {
-            t.error(err);
-
-            var found = containers.filter(function (c) {
-                if (c.Id === id) {
-                    return true;
-                }
-            });
-
-            t.equal(found.length, 1, 'found our container');
-
-            var matched = found[0].Status.match(/^Up /);
-            t.ok(matched, 'container has started');
-            if (!matched) {
-                t.equal(found[0].Status, 'Status for debugging');
-            }
-
-            t.end();
-        });
-    });
-
-
-    tt.test('kill container with valid numeric signal', function (t) {
-        DOCKER.post('/containers/' + id + '/kill?signal=9', onpost);
-        function onpost(err, res, req, body) {
-            t.error(err);
-            t.end(err);
-        }
-    });
-
-
-    tt.test('confirm container killed', function (t) {
-        container.checkContainerStatus(id, /^Exited /, {
-            helper: h,
-            dockerClient: DOCKER,
-            retries: 10
-        }, function _onCheckDone(err, success) {
-            t.ifErr(err, 'Checking container status should not error');
-            t.ok(success, 'Container should be in status exited');
-
-            t.end();
-        });
-    });
-
-    tt.test('restart container', function (t) {
-        DOCKER.post('/containers/' + id + '/restart', onpost);
-        function onpost(err, res, req, body) {
-            t.error(err);
-            t.end(err);
-        }
-    });
-
-
-    tt.test('confirm container restarted', function (t) {
-        h.listContainers({
-            all: true,
-            dockerClient: DOCKER,
-            test: t
-        }, function (err, containers) {
-            t.error(err);
-
-            var found = containers.filter(function (c) {
-                if (c.Id === id) {
-                    return true;
-                }
-            });
-
-            t.equal(found.length, 1, 'found our container');
-
-            var matched = found[0].Status.match(/^Up /);
-            t.ok(matched, 'container has started');
-            if (!matched) {
-                t.equal(found[0].Status, 'Status for debugging');
-            }
-
-            t.end();
-        });
-    });
-
-
-    tt.test('kill container with valid symbolic signal', function (t) {
-        DOCKER.post('/containers/' + id + '/kill?signal=SIGKILL', onpost);
-        function onpost(err, res, req, body) {
-            t.error(err);
-            t.end(err);
-        }
-    });
-
-
-    tt.test('confirm container killed', function (t) {
-        container.checkContainerStatus(id, /^Exited /, {
-            helper: h,
-            dockerClient: DOCKER,
-            retries: 10
-        }, function _onCheckDone(err, success) {
-            t.ifErr(err, 'Checking container status should not error');
-            t.ok(success, 'Container should be in status exited');
-
-            t.end();
-        });
-    });
-
     tt.test('delete container', function (t) {
-        DOCKER.del('/containers/' + id, ondel);
+        DOCKER.del('/containers/' + id + '?force=true', ondel);
 
         function ondel(err, res, req, body) {
             t.ifErr(err, 'rm container');

--- a/test/integration/api-start-stop-restart.test.js
+++ b/test/integration/api-start-stop-restart.test.js
@@ -159,8 +159,8 @@ test('api: restart', function (tt) {
         DOCKER.post('/containers/' + id + '/restart?t=foo', onpost);
         function onpost(err, res, req, body) {
             var expectedResponseStatusCode = 422;
-            var expectedErrorMessage = '(Validation) Invalid parameters: foo '
-                + 'does not represent a number';
+            var expectedErrorMessage = '(Validation) Invalid parameters: '
+                + 'Invalid parameter "t": "foo" does not represent a number';
 
             t.ok(err, 'Response should be an error');
             t.equal(err.statusCode, expectedResponseStatusCode,

--- a/test/integration/cli-copy.test.js
+++ b/test/integration/cli-copy.test.js
@@ -204,7 +204,7 @@ test('copy out of container file placement', function (tt) {
     function initializeFixtures(callback) {
         vasync.waterfall([
             function createDir(next) {
-                cli.exec(sprintf('mkdir -p %s', directoryName),
+                cli.execInTestZone(sprintf('mkdir -p %s', directoryName),
                 function (err, stdout, stderr) {
                     tt.ifErr(err, 'creating test directory');
                     tt.comment('created ' + directoryName);
@@ -242,7 +242,7 @@ test('copy out of container file placement', function (tt) {
             tt.ifErr(err, 'no `docker copy` error');
 
             // TODO better mechanism for checking existence of resulting file
-            cli.exec(sprintf('ls %s', result), function (execErr) {
+            cli.execInTestZone(sprintf('ls %s', result), function (execErr) {
                 tt.ifErr(execErr,
                     'checking for existence of resulting docker copy file');
                 callback();
@@ -530,7 +530,7 @@ function createCopyInFile(tt, ffn, callback) {
         + 'count=1024 bs=1024 >/dev/null && '
         + '/native/usr/bin/sum -x sha1 %s | awk "{ print $1 }"',
         ffn, ffn);
-    cli.exec(cmd, function (err, stdout, stderr) {
+    cli.execInTestZone(cmd, function (err, stdout, stderr) {
         tt.ifErr(err);
         hash = stdout.toString();
         callback(err, hash);

--- a/test/integration/cli-kill.test.js
+++ b/test/integration/cli-kill.test.js
@@ -1,0 +1,488 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (c) 2016, Joyent, Inc.
+ */
+
+/*
+ * Integration tests for `docker kill`
+ */
+
+var assert = require('assert-plus');
+var test = require('tape');
+var vasync = require('vasync');
+
+
+var cli = require('../lib/cli');
+var container = require('../lib/container');
+var h = require('./helpers');
+var log = require('../lib/log');
+var signals = require('../../lib/signals');
+
+var STATE = {
+    log: log
+};
+
+var ALICE;
+var DOCKER_API_CLIENT;
+var IMAGE_NAME = 'joyent/test-echo-signals:latest';
+
+function removeUnsupportedSignals(signal) {
+    assert.string(signal, 'signal');
+
+    signal = signals.toLongSignalName(signal);
+
+    // Sending SIGSTKFLT is currently _not_ supported on Triton because it maps
+    // to SIGEMT on SmartOS, which is not supported by node-vmadm.
+    return signal !== 'SIGSTKFLT' && signal !== '16';
+}
+
+function removeStoppingSignals(signal) {
+    assert.string(signal, 'signal');
+
+    signal = signals.toLongSignalName(signal);
+
+    // Sending SIGSTOP (19) stops the init process running in a container. Thus,
+    // any subsequent signal sent would not be handled since the init process
+    // would be stop. So this tests suite does not test that SIGSTOP is properly
+    // handled in the test that checks for other signals, and instead it tests
+    // it in a separate test.
+    return signal !== 'SIGSTOP' && signal !== '19';
+}
+
+function removeKillingSignals(signal) {
+    assert.string(signal, 'signal');
+
+    signal = signals.toLongSignalName(signal);
+
+    // SIGKILL (9) and SIGSTOP (19) are the only signals for which one cannot
+    // setup a custom handler and whose default behavior is to kill the process.
+    // So if we want to keep the container alive in order to test that all other
+    // signals are properly sent and received, we must avoid sending them. The
+    // behavior for these two signals is tested separately.
+    return signal !== 'SIGKILL' && signal !== '9' && signal !== 'SIGSTOP'
+        && signal !== '19';
+}
+
+function removeZeroSignal(signal) {
+    assert.string(signal, 'signal');
+
+    return signal !== '0';
+}
+
+function testSignal(t, targetContainerId, signal, callback) {
+    assert.object(t, 't');
+    assert.string(targetContainerId, 'containerId');
+    assert.string(signal, 'signal');
+    assert.func(callback, 'callback');
+
+    vasync.pipeline({
+        funcs: [
+            function sendSignal(args, next) {
+                cli.kill({
+                    args: '-s ' + signal + ' ' + targetContainerId,
+                    t: t
+                },
+                function onKillDone(err, stdout, stderr) {
+                    next(err);
+                    return;
+                });
+            },
+            function checkSignalReceived(args, next) {
+                var signalName = signal;
+                if (!isNaN(Number(signal))) {
+                    signalName = signals.linuxSignalNames[signal];
+                }
+
+                assert.string(signalName, 'signalName');
+
+                cli.logs(t, { args: targetContainerId},
+                    function onLogsDone(err, stdout, stderr) {
+                        t.ok(stdout.match(signalName), 'sent signal ' + signal
+                            + ' and ' + signals.toLongSignalName(signalName)
+                            + ' should have been received');
+
+                        next(err);
+                        return;
+                    });
+            }
+        ]
+    },
+    function testDone(err) {
+        // Do not forward error since we don't want to abort
+        // the pipeline even if some tests failed: we want to
+        // run all tests.
+        callback();
+        return;
+    });
+}
+
+function testStatusAfterSendingSignal(t, signal, expectedStatus) {
+    assert.object(t, 't');
+    assert.string(signal, 'signal');
+    assert.regexp(expectedStatus, 'expectedStatus');
+
+    var containerId;
+
+    vasync.pipeline({
+        funcs: [
+            function createContainer(args, next) {
+                cli.run(t, { args: '-d ' + IMAGE_NAME}, function (err, id) {
+                    t.ifErr(err, 'docker run ' + IMAGE_NAME
+                        + ' should not error');
+                    containerId = id;
+
+                    next(err);
+                    return;
+                });
+            },
+            function sendSignal(args, next) {
+                var dockerKillArgs = [];
+
+                if (signal.length > 0) {
+                    dockerKillArgs = dockerKillArgs.concat('-s', signal);
+                }
+
+                dockerKillArgs.push(containerId);
+
+                cli.kill({
+                    args: dockerKillArgs.join(' ')
+                }, function onKillDone(err, stdout, stderr) {
+                        t.ifErr(err, 'Sending signal ' + signal
+                            + ' should not error');
+
+                        next(err);
+                        return;
+                    });
+            },
+            function checkContainerExited(args, next) {
+                container.checkContainerStatus(containerId, expectedStatus, {
+                    helper: h,
+                    dockerClient: DOCKER_API_CLIENT,
+                    retries: 10
+                }, function _onCheckDone(err, success) {
+                    t.ifErr(err, 'Checking container status should not error');
+                    t.ok(success, 'Container should be in status '
+                        + expectedStatus);
+
+                    next(err);
+                    return;
+                });
+            }
+        ]
+    },
+    function testDone(err) {
+        cli.rm(t, {args: ['-f', containerId].join(' ')},
+            function onContainerDeleted(rmErr) {
+                t.end();
+                return;
+            });
+    });
+}
+
+function testSignalUnsupported(t, signal) {
+    assert.object(t, 't');
+    assert.string(signal, 'signal');
+
+    var containerId;
+
+    vasync.pipeline({
+        funcs: [
+            function createContainer(args, next) {
+                cli.run(t, { args: '-d ' + IMAGE_NAME}, function (err, id) {
+                    t.ifErr(err, 'docker run ' + IMAGE_NAME
+                        + ' should not error');
+                    containerId = id;
+
+                    next(err);
+                    return;
+                });
+            },
+            function sendSignal(args, next) {
+                cli.kill({ args: '-s ' + signal + ' ' + containerId},
+                    function onKillDone(err, stdout, stderr) {
+                        t.ok(err, 'Sending signal ' + signal + ' should error');
+
+                        if (!err) {
+                            next(new Error('Sending unsupported signal '
+                            + signal
+                            + ' should have resulted in an error'));
+                        } else {
+                            next();
+                        }
+
+                        return;
+                    });
+            }
+        ]
+    },
+    function testDone(err) {
+        t.ifErr(err);
+
+        cli.rm(t, {args: ['-f', containerId].join(' ')},
+            function onContainerDeleted(rmErr) {
+                t.end();
+                return;
+            });
+    });
+}
+
+function testSignalStopsProcess(t, signal) {
+    assert.object(t, 't');
+    assert.string(signal, 'signal');
+
+    var containerId;
+
+    vasync.pipeline({
+        funcs: [
+            function createContainer(args, next) {
+                cli.run(t, { args: '-d ' + IMAGE_NAME}, function (err, id) {
+                    t.ifErr(err, 'docker run ' + IMAGE_NAME
+                        + ' should not error');
+                    containerId = id;
+
+                    next(err);
+                    return;
+                });
+            },
+            function sendSignal(args, next) {
+                cli.kill({ args: '-s ' + signal + ' ' + containerId},
+                    function onKillDone(err, stdout, stderr) {
+                        t.ifErr(err, 'Sending signal ' + signal
+                            + ' should not error');
+
+                        next(err);
+                        return;
+                    });
+            },
+            function checkInitProcessStopped(args, next) {
+                var nbRetries = 0;
+                var MAX_RETRIES = 10;
+
+                function checkProcessStatus(callback) {
+                    cli.exec(t, {args: containerId + ' cat /proc/1/status'},
+                        callback);
+                }
+
+                function onProcessStatusChecked(err, stdout, stderr) {
+                    var processStopped = false;
+                    ++nbRetries;
+
+                    if (err) {
+                        next(err);
+                        return;
+                    }
+
+                    processStopped = stdout.indexOf('State:	T (stopped)')
+                        !== -1;
+
+                    if (processStopped || nbRetries >= MAX_RETRIES) {
+                        t.ok(processStopped,
+                            'init process should be in state stopped');
+                        next();
+                        return;
+                    } else {
+                        setTimeout(function retryCheckProcessStatus() {
+                            checkProcessStatus(onProcessStatusChecked);
+                        }, 1000);
+                    }
+                }
+
+                checkProcessStatus(onProcessStatusChecked);
+            }
+        ]
+    },
+    function testDone(err) {
+        t.ifErr(err);
+
+        cli.rm(t, {args: ['-f', containerId].join(' ')},
+            function onContainerDeleted(rmErr) {
+                t.end();
+                return;
+            });
+    });
+}
+
+// Takes a list of signals as strings "signalsList" and returns a new list
+// that contains only signals that can be handled by a custom signal handler
+// without making a process exit.
+function removeUnhandledSignals(signalsList) {
+    assert.arrayOfString(signalsList, 'signals');
+    var handledSignals = signalsList.slice(0);
+
+    handledSignals = handledSignals.filter(removeKillingSignals);
+    handledSignals = handledSignals.filter(removeUnsupportedSignals);
+    handledSignals = handledSignals.filter(removeStoppingSignals);
+    handledSignals = handledSignals.filter(removeZeroSignal);
+
+    return handledSignals;
+}
+
+test('setup', function (tt) {
+
+    tt.test('docker env', function (t) {
+        h.getDockerEnv(t, STATE, {account: 'sdcdockertest_alice'},
+                function (err, env) {
+            t.ifErr(err, 'docker env: alice');
+            t.ok(env, 'have a DockerEnv for alice');
+            ALICE = env;
+
+            t.end();
+        });
+    });
+
+    tt.test('DockerEnv: alice init', function (t) {
+        cli.init(t, ALICE);
+    });
+
+    tt.test('Docker API client init', function (t) {
+        h.createDockerRemoteClient({user: ALICE}, function (err, client) {
+            t.ifErr(err, 'docker client init');
+            DOCKER_API_CLIENT = client;
+
+            t.end();
+        });
+    });
+
+    tt.test('pull joyent/test-echo-signals image', function (t) {
+        cli.pull(t, {
+            image: 'joyent/test-echo-signals:latest'
+        });
+    });
+});
+
+test('docker kill with default signal makes a container\'s init process exit',
+    function (t) {
+        testStatusAfterSendingSignal(t, '', /^Exited /);
+    });
+
+
+test('docker kill with signal numbers sends the proper signal to containers',
+    function (t) {
+        function mapSignalNumber(signalName, index) {
+            return '' + index;
+        }
+
+        var containerId;
+
+        var linuxSignalNumbers = signals.linuxSignalNames.map(mapSignalNumber);
+        linuxSignalNumbers = removeUnhandledSignals(linuxSignalNumbers);
+
+        cli.run(t, { args: '-d ' + IMAGE_NAME}, function (dockerRunErr, id) {
+            t.ifErr(dockerRunErr, 'docker run ' + IMAGE_NAME);
+            containerId = id;
+
+            vasync.forEachPipeline({
+                func: testSignal.bind(null, t, containerId),
+                inputs: linuxSignalNumbers
+            }, function allTestsDone(err) {
+                t.ifErr(err);
+                cli.rm(t, {args: ['-f', containerId].join(' ')},
+                    function onContainerDeleted(delErr) {
+                        t.end();
+                        return;
+                    });
+            });
+        });
+    });
+
+test('docker kill with signal number 9 makes a container\'s init process exit',
+    function (t) {
+        testStatusAfterSendingSignal(t, '9', /^Exited /);
+    });
+
+test('docker kill with signal 16 is not supported', function (t) {
+    testSignalUnsupported(t, '16');
+});
+
+test('docker kill with signal number 19 stops a container\'s init process',
+    function (t) {
+        testSignalStopsProcess(t, '19');
+    });
+
+test('docker kill with short signal names sends the proper signal to '
+    + 'containers', function (t) {
+    var containerId;
+    var linuxSignalNames = signals.linuxSignalNames;
+    linuxSignalNames = removeUnhandledSignals(linuxSignalNames);
+
+    cli.run(t, { args: '-d ' + IMAGE_NAME}, function (dockerRunErr, id) {
+        t.ifErr(dockerRunErr, 'docker run ' + IMAGE_NAME);
+        containerId = id;
+
+        vasync.forEachPipeline({
+            func: testSignal.bind(null, t, containerId),
+            inputs: linuxSignalNames
+        }, function allTestsDone(err) {
+            t.ifErr(err);
+            cli.rm(t, {args: ['-f', containerId].join(' ')},
+                function onContainerDeleted(delErr) {
+                    t.end();
+                    return;
+                });
+        });
+    });
+});
+
+test('docker kill with long signal names sends the proper signal to '
+    + 'containers', function (t) {
+    var containerId;
+    var linuxSignalNames = signals.linuxSignalNames;
+    var longLinuxSignalNames;
+
+    linuxSignalNames = removeUnhandledSignals(linuxSignalNames);
+    longLinuxSignalNames = linuxSignalNames.map(signals.toLongSignalName);
+
+    cli.run(t, { args: '-d ' + IMAGE_NAME}, function (dockerRunErr, id) {
+        t.ifErr(dockerRunErr, 'docker run ' + IMAGE_NAME);
+        containerId = id;
+
+        vasync.forEachPipeline({
+            func: testSignal.bind(null, t, containerId),
+            inputs: longLinuxSignalNames
+        }, function allTestsDone(err) {
+            t.ifErr(err);
+            cli.rm(t, {args: ['-f', containerId].join(' ')},
+                function onContainerDeleted(delErr) {
+                    t.end();
+                    return;
+                });
+        });
+    });
+});
+
+test('docker kill with signal SIGKILL makes a container\'s init process exit',
+    function (t) {
+        testStatusAfterSendingSignal(t, 'SIGKILL', /^Exited /);
+    });
+
+test('docker kill with signal KILL makes a container\'s init process exit',
+    function (t) {
+        testStatusAfterSendingSignal(t, 'KILL', /^Exited /);
+    });
+
+test('docker kill with signal SIGSTKFLT is not supported', function (t) {
+    testSignalUnsupported(t, 'SIGSTKFLT');
+});
+
+test('docker kill with signal STKFLT is not supported', function (t) {
+    testSignalUnsupported(t, 'STKFLT');
+});
+
+test('docker kill with signal SIGSTOP stops a container\'s init process',
+    function (t) {
+        testSignalStopsProcess(t, 'SIGSTOP');
+    });
+
+test('docker kill with signal STOP stops a container\'s init process',
+    function (t) {
+        testSignalStopsProcess(t, 'STOP');
+    });
+
+test('docker kill with signal \'0\' results in a request error', function (t) {
+    testSignalUnsupported(t, '0');
+});

--- a/test/integration/fixtures/test-echo-signals-container/Dockerfile
+++ b/test/integration/fixtures/test-echo-signals-container/Dockerfile
@@ -1,0 +1,4 @@
+# Use mhart/alpine-node because it's a small image
+FROM mhart/alpine-node:4
+COPY ./echo-signals.js ./echo-signals.js
+CMD ["node", "./echo-signals.js"]

--- a/test/integration/fixtures/test-echo-signals-container/echo-signals.js
+++ b/test/integration/fixtures/test-echo-signals-container/echo-signals.js
@@ -1,0 +1,45 @@
+var linuxSignalNames = [
+    'SIGHUP',
+    'SIGINT',
+    'SIGQUIT',
+    'SIGILL',
+    'SIGTRAP',
+    'SIGABRT',
+    'SIGBUS',
+    'SIGFPE',
+    'SIGUSR1',
+    'SIGSEGV',
+    'SIGUSR2',
+    'SIGPIPE',
+    'SIGALRM',
+    'SIGTERM',
+    // Please not that for now we do not support sending SIGSTKFLT to a Docker
+    // container, so the handler set for it would not be called. However, we
+    // should be able to support that eventually, so we still set it up.
+    'SIGSTKFLT',
+    'SIGCHLD',
+    'SIGCONT',
+    'SIGTSTP',
+    'SIGTTIN',
+    'SIGTTOU',
+    'SIGURG',
+    'SIGXCPU',
+    'SIGXFSZ',
+    'SIGVTALRM',
+    'SIGPROF',
+    'SIGWINCH',
+    'SIGPOLL',
+    'SIGPWR',
+    'SIGSYS'
+];
+
+linuxSignalNames.forEach(function setupSignalHandler(signalName) {
+    process.on(signalName, function onSignal() {
+        console.log(signalName);
+    });
+});
+
+// Hold the loop open without using I/O from stdin so that this code can be run
+// by a Docker container started in detached mode (with docker run -d).
+setInterval(function noOp() {
+}, 10 * 1000);

--- a/test/integration/fixtures/test-echo-signals-container/package.json
+++ b/test/integration/fixtures/test-echo-signals-container/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "test-echo-signals",
+  "version": "1.0.0",
+  "description": "A program that echoes on stdout any signal sent to it.",
+  "main": "echo-signals.js",
+  "scripts": {
+    "start": "node echo-signals.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Julien Gilli",
+  "license": "MPL-2.0"
+}

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -704,7 +704,7 @@ GzDockerEnv.prototype.init = function denvInit(t, state_, cb) {
             }
 
             p('# Running "sdc-docker-setup.sh" for "%s" account', self.login);
-            self.exec(
+            self.execInTestZone(
                 fmt(
                     '/root/bin/sdc-docker-setup.sh -k %s %s '
                         + '/root/.ssh/%s.id_rsa',
@@ -734,7 +734,7 @@ GzDockerEnv.prototype.docker = function denvDocker(cmd, opts, cb) {
     var dockerCmd = fmt(
         '(source /root/.sdc/docker/%s/env.sh; /root/bin/docker-%s --tls %s)',
         this.login, process.env.DOCKER_CLI_VERSION, cmd);
-    this.exec(dockerCmd, opts, cb);
+    this.execInTestZone(dockerCmd, opts, cb);
 };
 
 /*
@@ -744,7 +744,7 @@ GzDockerEnv.prototype.docker = function denvDocker(cmd, opts, cb) {
  * @param opts {Object} Optional. Nothing yet.
  * @param cb {Function} `function (err, stdout, stderr)`
  */
-GzDockerEnv.prototype.exec = function denvExec(cmd, opts, cb) {
+GzDockerEnv.prototype.execInTestZone = function denvExec(cmd, opts, cb) {
     assert.string(cmd, 'cmd');
     if (cb === undefined) {
         cb = opts;
@@ -911,7 +911,7 @@ LocalDockerEnv.prototype.docker = function ldenvDocker(cmd, opts, cb) {
     var dockerCmd = fmt(
         '(source ~/.sdc/docker/%s/env.sh; docker --tls %s)',
         this.login, cmd);
-    this.exec(dockerCmd, opts, cb);
+    this.execInTestZone(dockerCmd, opts, cb);
 };
 
 /*
@@ -921,7 +921,7 @@ LocalDockerEnv.prototype.docker = function ldenvDocker(cmd, opts, cb) {
  * @param opts {Object} Optional. Nothing yet.
  * @param cb {Function} `function (err, stdout, stderr)`
  */
-LocalDockerEnv.prototype.exec = function ldenvExec(cmd, opts, cb) {
+LocalDockerEnv.prototype.execInTestZone = function ldenvExec(cmd, opts, cb) {
     assert.string(cmd, 'cmd');
     if (cb === undefined) {
         cb = opts;

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -1510,14 +1510,20 @@ function listContainers(opts, callback) {
                 '/containers/json'
                 + (opts.all ? '?all=1' : ''), onget);
             function onget(err, res, req, body) {
-                t.error(err);
+                if (t) {
+                    t.error(err);
+                }
+
                 containers = body;
                 next(err);
             }
         }
     ],
     function (err) {
-        t.error(err);
+        if (t) {
+            t.error(err);
+        }
+
         callback(err, containers);
     });
 }

--- a/test/lib/container.js
+++ b/test/lib/container.js
@@ -1,0 +1,51 @@
+var assert = require('assert-plus');
+
+function checkContainerStatus(containerId, statusPattern, options, callback) {
+    assert.string(containerId, 'containerId');
+    assert.regexp(statusPattern, 'statusPattern');
+    assert.object(options, 'options');
+    assert.object(options.helper, 'options.helper');
+    assert.object(options.dockerClient, 'options.dockerClient');
+    assert.func(callback, 'callback');
+
+    var helper = options.helper;
+    var dockerClient = options.dockerClient;
+
+    var retries = options.retries || 10;
+    var nbChecksPerformed = 0;
+
+    assert.ok(retries > 0, 'retries must be a positive number');
+
+    function performCheck() {
+        ++nbChecksPerformed;
+        console.log('nbChecksPerformed: %d out of %d', nbChecksPerformed,
+            retries);
+        helper.listContainers({
+            all: true,
+            dockerClient: dockerClient
+        }, function (err, containers) {
+            if (err) {
+                return callback(err);
+            }
+
+            var found = containers.filter(function (c) {
+                if (c.Id === containerId) {
+                    return true;
+                }
+            });
+
+            var matched = found[0].Status.match(statusPattern);
+            if (matched || nbChecksPerformed >= retries) {
+                return callback(null, matched);
+            } else {
+                performCheck();
+            }
+        });
+    }
+
+    performCheck();
+}
+
+module.exports = {
+    checkContainerStatus: checkContainerStatus
+};

--- a/test/lib/container.js
+++ b/test/lib/container.js
@@ -18,8 +18,7 @@ function checkContainerStatus(containerId, statusPattern, options, callback) {
 
     function performCheck() {
         ++nbChecksPerformed;
-        console.log('nbChecksPerformed: %d out of %d', nbChecksPerformed,
-            retries);
+
         helper.listContainers({
             all: true,
             dockerClient: dockerClient

--- a/test/unit/signals.test.js
+++ b/test/unit/signals.test.js
@@ -1,0 +1,454 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (c) 2016, Joyent, Inc.
+ */
+
+var test = require('tape');
+
+var signals = require('../../lib/signals');
+
+var VALID_SIGNAL_NUMBERS = [];
+for (var i = 0; i < signals.linuxSignalNames.length; ++i) {
+    VALID_SIGNAL_NUMBERS.push('' + i);
+}
+
+var VALID_LINUX_LONG_SIGNAL_NAMES = [
+    '0', 'SIGHUP', 'SIGINT', 'SIGQUIT', 'SIGILL', 'SIGTRAP', 'SIGABRT',
+    'SIGBUS', 'SIGFPE', 'SIGKILL', 'SIGUSR1', 'SIGSEGV', 'SIGUSR2',
+    'SIGPIPE', 'SIGALRM', 'SIGTERM', 'SIGSTKFLT', 'SIGCHLD', 'SIGCONT',
+    'SIGSTOP', 'SIGTSTP', 'SIGTTIN', 'SIGTTOU', 'SIGURG', 'SIGXCPU',
+    'SIGXFSZ', 'SIGVTALRM', 'SIGPROF', 'SIGWINCH', 'SIGPOLL', 'SIGPWR',
+    'SIGSYS'
+];
+
+var VALID_LINUX_SHORT_SIGNAL_NAMES = [
+    '0', 'HUP', 'INT', 'QUIT', 'ILL', 'TRAP', 'ABRT',
+    'BUS', 'FPE', 'KILL', 'USR1', 'SEGV', 'USR2', 'PIPE',
+    'ALRM', 'TERM', 'STKFLT', 'CHLD', 'CONT', 'STOP',
+    'TSTP', 'TTIN', 'TTOU', 'URG', 'XCPU', 'XFSZ',
+    'VTALRM', 'PROF', 'WINCH', 'POLL', 'PWR', 'SYS'
+];
+
+var SMARTOS_ONLY_LONG_SIGNAL_NAMES = [
+    'SIGWAITING', 'SIGLWP', 'SIGFREEZE', 'SIGTHAW', 'SIGCANCEL', 'SIGLOST',
+    'SIGXRES', 'SIGINFO'
+];
+
+var SMARTOS_ONLY_SHORT_SIGNAL_NAMES = [
+    'WAITING', 'LWP', 'FREEZE', 'THAW', 'CANCEL', 'LOST', 'XRES', 'INFO'
+];
+
+var INVALID_SIGNAL_NAMES = ['', 'foo'];
+
+var NON_STRING_SIGNALS = [
+    6, {}, undefined, null
+];
+
+var LINUX_TO_SMARTOS_SHORT_SYMBOLIC_NAMES = {
+    '0':         '0',
+    'HUP':       'SIGHUP',
+    'INT':       'SIGINT',
+    'QUIT':      'SIGQUIT',
+    'ILL':       'SIGILL',
+    'TRAP':      'SIGTRAP',
+    'ABRT':      'SIGABRT',
+    'BUS':       'SIGBUS',
+    'FPE':       'SIGFPE',
+    'KILL':      'SIGKILL',
+    'USR1':      'SIGUSR1',
+    'SEGV':      'SIGSEGV',
+    'USR2':      'SIGUSR2',
+    'PIPE':      'SIGPIPE',
+    'ALRM':      'SIGALRM',
+    'TERM':      'SIGTERM',
+    'STKFLT':    'SIGEMT',
+    'CHLD':      'SIGCHLD',
+    'CONT':      'SIGCONT',
+    'STOP':      'SIGSTOP',
+    'TSTP':      'SIGTSTP',
+    'TTIN':      'SIGTTIN',
+    'TTOU':      'SIGTTOU',
+    'URG':       'SIGURG',
+    'XCPU':      'SIGXCPU',
+    'XFSZ':      'SIGXFSZ',
+    'VTALRM':    'SIGVTALRM',
+    'PROF':      'SIGPROF',
+    'WINCH':     'SIGWINCH',
+    'POLL':      'SIGPOLL',
+    'PWR':       'SIGPWR',
+    'SYS':       'SIGSYS'
+};
+
+var LINUX_TO_SMARTOS_LONG_SYMBOLIC_NAMES = {
+    '0':            '0',
+    'SIGHUP':       'SIGHUP',
+    'SIGINT':       'SIGINT',
+    'SIGQUIT':      'SIGQUIT',
+    'SIGILL':       'SIGILL',
+    'SIGTRAP':      'SIGTRAP',
+    'SIGABRT':      'SIGABRT',
+    'SIGBUS':       'SIGBUS',
+    'SIGFPE':       'SIGFPE',
+    'SIGKILL':      'SIGKILL',
+    'SIGUSR1':      'SIGUSR1',
+    'SIGSEGV':      'SIGSEGV',
+    'SIGUSR2':      'SIGUSR2',
+    'SIGPIPE':      'SIGPIPE',
+    'SIGALRM':      'SIGALRM',
+    'SIGTERM':      'SIGTERM',
+    'SIGSTKFLT':    'SIGEMT',
+    'SIGCHLD':      'SIGCHLD',
+    'SIGCONT':      'SIGCONT',
+    'SIGSTOP':      'SIGSTOP',
+    'SIGTSTP':      'SIGTSTP',
+    'SIGTTIN':      'SIGTTIN',
+    'SIGTTOU':      'SIGTTOU',
+    'SIGURG':       'SIGURG',
+    'SIGXCPU':      'SIGXCPU',
+    'SIGXFSZ':      'SIGXFSZ',
+    'SIGVTALRM':    'SIGVTALRM',
+    'SIGPROF':      'SIGPROF',
+    'SIGWINCH':     'SIGWINCH',
+    'SIGPOLL':      'SIGPOLL',
+    'SIGPWR':       'SIGPWR',
+    'SIGSYS':       'SIGSYS'
+};
+
+var LINUX_SIG_NUMBER_TO_SMARTOS_SIG_NAME = [
+    '0',
+    'SIGHUP',
+    'SIGINT',
+    'SIGQUIT',
+    'SIGILL',
+    'SIGTRAP',
+    'SIGABRT',
+    'SIGBUS',
+    'SIGFPE',
+    'SIGKILL',
+    'SIGUSR1',
+    'SIGSEGV',
+    'SIGUSR2',
+    'SIGPIPE',
+    'SIGALRM',
+    'SIGTERM',
+    'SIGEMT',
+    'SIGCHLD',
+    'SIGCONT',
+    'SIGSTOP',
+    'SIGTSTP',
+    'SIGTTIN',
+    'SIGTTOU',
+    'SIGURG',
+    'SIGXCPU',
+    'SIGXFSZ',
+    'SIGVTALRM',
+    'SIGPROF',
+    'SIGWINCH',
+    'SIGPOLL',
+    'SIGPWR',
+    'SIGSYS'
+];
+
+test('signals.toLongSignalName with signal numbers', function (t) {
+    function testSigNumberToLongSignalName(signalNumber) {
+        t.equal(signalNumber, signals.toLongSignalName(signalNumber),
+            'signals.toLongSignalName(\'' + signalNumber + '\') === \''
+            + signalNumber + '\'');
+    }
+
+    VALID_SIGNAL_NUMBERS.forEach(testSigNumberToLongSignalName);
+
+    t.end();
+});
+
+test('signals.toLongSignalName with long signal names', function (t) {
+    function testLongToLong(longSignalName) {
+        t.equal(longSignalName, signals.toLongSignalName(longSignalName),
+            'signals.toLongSignalName(\'' + longSignalName + '\') === \''
+            + longSignalName + '\'');
+    }
+
+    VALID_LINUX_LONG_SIGNAL_NAMES.forEach(testLongToLong);
+
+    t.end();
+});
+
+test('signals.toLongSignalName with short signal names', function (t) {
+    function testShortToLong(shortSignalName) {
+        var expectedResult = 'SIG' + shortSignalName;
+        if (shortSignalName === '0') {
+            expectedResult = '0';
+        }
+
+        t.equal(expectedResult, signals.toLongSignalName(shortSignalName),
+            'signals.toLongSignalName(\'' + shortSignalName + '\') === \''
+            + expectedResult + '\'');
+    }
+
+    VALID_LINUX_SHORT_SIGNAL_NAMES.forEach(testShortToLong);
+
+    t.end();
+});
+
+test('signals.toLongSignalName with invalid signal names', function (t) {
+    INVALID_SIGNAL_NAMES.forEach(function testInvalidToLong(invalidSignalName) {
+        t.equal(invalidSignalName, signals.toLongSignalName(invalidSignalName),
+            'signals.toLongSignalName(\'' + invalidSignalName + '\') === \''
+            + invalidSignalName + '\'');
+    });
+
+    t.end();
+});
+
+test('signals.toLongSignalName throws on non-string signal parameter',
+    function (t) {
+        var nonStringSignals = [6, {}, undefined, null];
+
+        nonStringSignals.forEach(function testNonStringToLong(nonStringSignal) {
+            t.throws(signals.toLongSignalName.bind(null, nonStringSignal),
+                'signals.toLongSignalName(' + nonStringSignal + ') throws');
+        });
+
+        t.end();
+    });
+
+test('signals.toShortSignalName with signal numbers', function (t) {
+    function testSigNumbertoShortSignalName(signalNumber) {
+        t.equal(signalNumber, signals.toShortSignalName(signalNumber),
+            'signals.toShortSignalName(\'' + signalNumber + '\') === \''
+            + signalNumber + '\'');
+    }
+
+    VALID_SIGNAL_NUMBERS.forEach(testSigNumbertoShortSignalName);
+
+    t.end();
+});
+
+test('signals.toShortSignalName with long signal names', function (t) {
+    function testLongToShort(longSignalName) {
+        var expectedResult = longSignalName.replace(/^SIG/, '');
+        t.equal(expectedResult, signals.toShortSignalName(longSignalName),
+            'signals.toShortSignalName(\'' + longSignalName + '\') === \''
+            + expectedResult + '\'');
+    }
+
+    VALID_LINUX_LONG_SIGNAL_NAMES.forEach(testLongToShort);
+
+    t.end();
+});
+
+test('signals.toShortSignalName with short signal names', function (t) {
+    function testShortToLong(shortSignalName) {
+        t.equal(shortSignalName, signals.toShortSignalName(shortSignalName),
+            'signals.toShortSignalName(\'' + shortSignalName + '\') === \''
+            + shortSignalName + '\'');
+    }
+
+    VALID_LINUX_SHORT_SIGNAL_NAMES.forEach(testShortToLong);
+
+    t.end();
+});
+
+test('signals.toShortSignalName with invalid signal names', function (t) {
+    function testInvalidToShort(invalidSignalName) {
+        t.equal(invalidSignalName, signals.toShortSignalName(invalidSignalName),
+            'signals.toShortSignalName(\'' + invalidSignalName + '\') === \''
+            + invalidSignalName + '\'');
+    }
+
+    INVALID_SIGNAL_NAMES.forEach(testInvalidToShort);
+
+    t.end();
+});
+
+test('signals.toShortSignalName throws on non-string signal parameter',
+    function (t) {
+        function testNonStringToShort(nonStringSignal) {
+            t.throws(signals.toShortSignalName.bind(null, nonStringSignal),
+                'signals.toShortSignalName(' + nonStringSignal + ') throws');
+        }
+
+        NON_STRING_SIGNALS.forEach(testNonStringToShort);
+
+        t.end();
+    });
+
+test('signals.isValidLinuxSignal returns true for long valid Linux signal '
+    + 'names', function (t) {
+        function checkIsValidLinuxLongSignal(validLinuxLongSignalName) {
+            t.ok(signals.isValidLinuxSignal(validLinuxLongSignalName),
+                'signals.isValidLinuxSignal(\'' + validLinuxLongSignalName
+                + '\') returns true');
+        }
+
+        VALID_LINUX_LONG_SIGNAL_NAMES.forEach(checkIsValidLinuxLongSignal);
+
+        t.end();
+    });
+
+
+test('signals.isValidLinuxSignal returns true for short valid Linux signal '
+    + 'names', function (t) {
+        function checkValidLinuxShortSignal(validLinuxShortSignalName) {
+            t.ok(signals.isValidLinuxSignal(validLinuxShortSignalName),
+                'signals.isValidLinuxSignal(\'' + validLinuxShortSignalName
+                + '\') returns true');
+        }
+
+        VALID_LINUX_SHORT_SIGNAL_NAMES.forEach(checkValidLinuxShortSignal);
+
+        t.end();
+    });
+
+
+test('signals.isValidLinuxSignal returns false for SmartOS only long signal '
+    + 'names', function (t) {
+        function checkSmartOSOnlyLongSignal(smartOSOnlyLongSignalName) {
+            t.notOk(signals.isValidLinuxSignal(smartOSOnlyLongSignalName),
+                'signals.isValidLinuxSignal(\'' + smartOSOnlyLongSignalName
+                + '\') returns false');
+        }
+
+        SMARTOS_ONLY_LONG_SIGNAL_NAMES.forEach(checkSmartOSOnlyLongSignal);
+
+        t.end();
+    });
+
+test('signals.isValidLinuxSignal returns false for SmartOS only short signal '
+    + 'names', function (t) {
+        function checkSmartOSOnlyShortSignal(smartOSOnlyShortSignalName) {
+            t.notOk(signals.isValidLinuxSignal(smartOSOnlyShortSignalName),
+                'signals.isValidLinuxSignal(\'' + smartOSOnlyShortSignalName
+                + '\') returns false');
+        }
+
+        SMARTOS_ONLY_SHORT_SIGNAL_NAMES.forEach(checkSmartOSOnlyShortSignal);
+
+        t.end();
+    });
+
+test('signals.isValidLinuxSignal returns false for invalid signal names',
+    function (t) {
+        INVALID_SIGNAL_NAMES.forEach(function (invalidSignalName) {
+            t.notOk(signals.isValidLinuxSignal(invalidSignalName),
+                'signals.isValidLinuxSignal(\'' + invalidSignalName
+                + '\') returns false');
+        });
+
+        t.end();
+    });
+
+test('signals.isValidLinuxSignal throws for non-string signal names',
+    function (t) {
+        NON_STRING_SIGNALS.forEach(function (nonStringSignal) {
+            t.throws(signals.isValidLinuxSignal.bind(null, nonStringSignal),
+                'signals.isValidLinuxSignal(' + nonStringSignal + ') throws');
+        });
+
+        t.end();
+    });
+
+test('signals.convertLinuxToSmartOSSignal returns undefined on invalid '
+    + 'signal names', function (t) {
+        function checkInvalidSignal(invalidSignalName) {
+            t.equal(signals.convertLinuxToSmartOSSignal(invalidSignalName),
+                undefined, 'signals.convertLinuxToSmartOSSignal('
+                + invalidSignalName + ') === undefined');
+        }
+
+        INVALID_SIGNAL_NAMES.forEach(checkInvalidSignal);
+
+        t.end();
+    });
+
+
+test('signals.convertLinuxToSmartOSSignal returns undefined on SmartOS-only '
+    + ' short signal name', function (t) {
+    function checkSmartOSOnlyShortSignal(smartOSOnlyShortSignalName) {
+        t.equal(signals.convertLinuxToSmartOSSignal(smartOSOnlyShortSignalName),
+        undefined, 'signals.convertLinuxToSmartOSSignal(\''
+            + smartOSOnlyShortSignalName +  '\') === undefined');
+    }
+
+    SMARTOS_ONLY_SHORT_SIGNAL_NAMES.forEach(checkSmartOSOnlyShortSignal);
+
+    t.end();
+});
+
+test('signals.convertLinuxToSmartOSSignal returns undefined on SmartOS-only '
+    + 'long signal name', function (t) {
+
+    function checkSmartOSOnlyLongSignal(smartOSOnlyLongSignalName) {
+        t.equal(signals.convertLinuxToSmartOSSignal(smartOSOnlyLongSignalName),
+        undefined, 'signals.convertLinuxToSmartOSSignal(\''
+            + smartOSOnlyLongSignalName +  '\') === undefined');
+    }
+
+    SMARTOS_ONLY_LONG_SIGNAL_NAMES.forEach(checkSmartOSOnlyLongSignal);
+
+    t.end();
+});
+
+test('signals.convertLinusToSmartOSSignal works for numeric signals',
+    function (t) {
+        function checkToSmartOSConversion(signalNumber) {
+            t.equal(LINUX_SIG_NUMBER_TO_SMARTOS_SIG_NAME[signalNumber],
+                signals.convertLinuxToSmartOSSignal(signalNumber),
+                'signals.convertLinuxToSmartOSSignal(\'' + signalNumber
+                + '\') === ' + '\''
+                + LINUX_SIG_NUMBER_TO_SMARTOS_SIG_NAME[signalNumber] + '\'');
+        }
+
+        VALID_SIGNAL_NUMBERS.forEach(checkToSmartOSConversion);
+
+        t.end();
+    });
+
+test('signals.convertLinusToSmartOSSignal works for short symbolic signal '
+    + 'names', function (t) {
+    function checkToSmartOSConversion(signalName) {
+        var expectedResult = LINUX_TO_SMARTOS_SHORT_SYMBOLIC_NAMES[signalName];
+        t.equal(expectedResult,
+            signals.convertLinuxToSmartOSSignal(signalName),
+            'signals.convertLinuxToSmartOSSignal(\'' + signalName
+            + '\') === ' + '\''
+            + expectedResult + '\'');
+    }
+
+    VALID_LINUX_SHORT_SIGNAL_NAMES.forEach(checkToSmartOSConversion);
+
+    t.end();
+});
+
+test('signals.convertLinusToSmartOSSignal works for long symbolic signal '
+    + 'names', function (t) {
+    function checkToSmartOSConversion(signalName) {
+        var expectedResult = LINUX_TO_SMARTOS_LONG_SYMBOLIC_NAMES[signalName];
+        t.equal(expectedResult,
+            signals.convertLinuxToSmartOSSignal(signalName),
+            'signals.convertLinuxToSmartOSSignal(\'' + signalName
+            + '\') === ' + '\''
+            + expectedResult + '\'');
+    }
+
+    VALID_LINUX_LONG_SIGNAL_NAMES.forEach(checkToSmartOSConversion);
+
+    t.end();
+});
+
+test('signals.convertLinuxToSmartOSSignal throws on invalid input',
+    function (t) {
+    NON_STRING_SIGNALS.forEach(function (nonStringSignal) {
+        t.throws(signals.convertLinuxToSmartOSSignal.bind(null,
+            nonStringSignal),
+            'signals.convertLinuxToSmartOSSignal(' + nonStringSignal
+            + ') throws');
+    });
+
+    t.end();
+});


### PR DESCRIPTION
The following endpoints:
- containerStop
- containerKill
- containerRestart

were missing a `queryParser` handler to parse the query string. As a result, none of their query string parameters were used. This problem was the result of a previous change that moved the `queryParser` from the `before` handlers to each specific endpoint that was using it.

This PR adds the `queryParser` handler to these three endpoints, and adds some basic tests that were missing, and that would have helped us find that the `queryParser` handler was missing in the first place.

In addition to these changes, this PR brings the following other notable changes:
1. It adds a check in error classes to make sure that their constructor is called with new, preventing hard to find bugs.
2. It adds some validation for timeout values in the `containerStop` and `containerRestart` endpoints, and for signal values in the `containerKill` endpoint.
3. It adds a new `test/lib/container.js` module that contains the `checkContainerStatus` function. This function is used to check if a container transitions to a given status and allows for a certain number of retries. This was needed in the `api-start-kill.js` integration test to make it non-flakey, since sometimes a killed container would not transition to the `stopped` status before we'd check its status.

This PR needs to land _after https://github.com/joyent/sdc-vmapi/pull/22, since otherwise it would pass numeric signal such as `'9'` as strings, which VMAPI doesn't accept before https://github.com/joyent/sdc-vmapi/pull/22.
