### PR TITLE
DOCKER-787 catch error when connecting for attach/exec

### DIFF
--- a/lib/backends/sdc/containers.js
+++ b/lib/backends/sdc/containers.js
@@ -3535,6 +3535,9 @@ function _runExec(opts, callback) {
     assert.object(opts.socketData, 'opts.socketData');
     assert.object(opts.socket, 'opts.socket');
 
+    // Make sure our callbacks get called only once
+    var cb = once(callback);
+
     var socketData = opts.socketData;
     var host = socketData.host;
     var port = socketData.port;
@@ -3572,18 +3575,17 @@ function _runExec(opts, callback) {
         serverSocket.end();
         cb(error, socketData);
     }
-    // Make sure our callbacks get called only once
+
     var endSocket = once(_endSocket);
-    var cb = once(callback);
 
     serverSocket.on('connect', setupListeners);
 
     // error can happen before connect too (eg. ECONNREFUSED)
-    serverSocket.on('error', function (error) {
+    serverSocket.on('error', function _onServerSocketError(error) {
         opts.log.error('serverSocket for %s threw an error %s',
             cmdString, error.toString());
 
-        endSocket(error);
+        cb(error);
     });
 
     function setupListeners() {
@@ -3655,7 +3657,6 @@ function _runAttach(opts, callback) {
             opts.log.debug('attach for %s threw an error %',
                 cmdString, error.toString());
 
-            serverSocket.end();
             cb(error);
         });
 

--- a/lib/backends/sdc/containers.js
+++ b/lib/backends/sdc/containers.js
@@ -3578,6 +3578,14 @@ function _runExec(opts, callback) {
 
     serverSocket.on('connect', setupListeners);
 
+    // error can happen before connect too (eg. ECONNREFUSED)
+    serverSocket.on('error', function (error) {
+        opts.log.error('serverSocket for %s threw an error %s',
+            cmdString, error.toString());
+
+        endSocket(error);
+    });
+
     function setupListeners() {
         if (socketData.command.AttachStdin) {
             clientSocket.on('data', function (chunk) {
@@ -3599,13 +3607,6 @@ function _runExec(opts, callback) {
 
         clientSocket.on('error', endSocket);
         clientSocket.on('timeout', endSocket);
-
-        serverSocket.on('error', function (error) {
-            opts.log.error('serverSocket for %s threw an error %s',
-                cmdString, error.toString());
-
-            endSocket(error);
-        });
 
         serverSocket.on('close', function (had_error) {
             opts.log.debug('serverSocket %s closed, had_error=%s',
@@ -3636,6 +3637,9 @@ function _runAttach(opts, callback) {
     assert.object(opts.socketData, 'opts.socketData');
     assert.object(opts.socket, 'opts.socket');
 
+    // Make sure our callbacks get called only once
+    var cb = once(callback);
+
     var socketData = opts.socketData;
     var host = socketData.host;
     var port = socketData.port;
@@ -3647,6 +3651,14 @@ function _runAttach(opts, callback) {
     if (!serverSocket) {
         serverSocket = net.createConnection({ host: host, port: port });
         serverSocket.on('connect', setupListeners);
+        serverSocket.on('error', function (error) {
+            opts.log.debug('attach for %s threw an error %',
+                cmdString, error.toString());
+
+            serverSocket.end();
+            cb(error);
+        });
+
         socketData.socket = serverSocket;
 
         // Store socket reference immediately
@@ -3686,9 +3698,7 @@ function _runAttach(opts, callback) {
             cb(error);
         }
 
-        // Make sure our callbacks get called only once
         var endSocket = once(_endSocket);
-        var cb = once(callback);
 
         // When we are attaching to an interactive TTY session we must support
         // resizing the console so our socket supports resize and data message
@@ -3735,13 +3745,6 @@ function _runAttach(opts, callback) {
 
         clientSocket.on('error', endSocket);
         clientSocket.on('timeout', endSocket);
-
-        serverSocket.on('error', function (error) {
-            opts.log.debug('attach for %s threw an error %',
-                cmdString, error.toString());
-
-            endSocket(error);
-        });
 
         serverSocket.on('close', function (had_error) {
             opts.log.debug('attach %s closed, had_error=%s',


### PR DESCRIPTION
When a connection to the agent fails with ECONNREFUSED, the restify domain's handler catches the error and we end up not calling /wait from the client. This means that:

```
docker run --rm node
```

sometimes works and sometimes bails because the container is still running (when we haven't run wait to see it stop). This fix makes it so that when a connection is refused we get the normal 400 response instead and the client calls wait.