### PR TITLE
DOCKER-788: update image/container filtering for new API format

### DIFF
--- a/lib/backends/sdc/containers.js
+++ b/lib/backends/sdc/containers.js
@@ -2321,12 +2321,12 @@ function getContainers(opts, callback) {
 
     if (opts.filters) {
         filters = JSON.parse(opts.filters);
-        filters = utils.getNormalizedFilters({ log: log }, filters);
+        filters = utils.getNormalizedFilters(filters);
         if (filters instanceof Error) {
             callback(new errors.DockerError('invalid filters: ' + filters));
             return;
         }
-        log.debug('filters: ', filters);
+        log.debug({filters: filters}, 'getContainers: filters');
     }
 
     vasync.pipeline({arg: {}, funcs: [

--- a/lib/backends/sdc/containers.js
+++ b/lib/backends/sdc/containers.js
@@ -2309,13 +2309,25 @@ function getContainers(opts, callback) {
     assert.object(opts.app.vmapi, 'opts.app.vmapi');
     assert.number(opts.clientApiVersion, 'opts.clientApiVersion');
     assert.arrayOfObject(opts.images, 'opts.images');
+    assert.optionalString(opts.filters, 'opts.filters');
     assert.optionalObject(opts.log, 'opts.log');
     assert.string(opts.req_id, 'opts.req_id');
 
+    var filters;
     var log = opts.log || this.log;
     var pkgmapNtoU = {};
     var pkgmapUtoN = {};
     var vmapi = opts.app.vmapi;
+
+    if (opts.filters) {
+        filters = JSON.parse(opts.filters);
+        filters = utils.getNormalizedFilters({ log: log }, filters);
+        if (filters instanceof Error) {
+            callback(new errors.DockerError('invalid filters: ' + filters));
+            return;
+        }
+        log.debug('filters: ', filters);
+    }
 
     vasync.pipeline({arg: {}, funcs: [
         function _listDockerVms(stash, cb) {
@@ -2386,27 +2398,15 @@ function getContainers(opts, callback) {
 
             cb();
         }, function _preloadPackages(stash, cb) {
-            var filters;
             var filteringOnPkgs = false;
             var i;
-            var invalidFilter;
             var invalidPackageName;
             var labelFilters;
             var labelSplit;
 
-            if (opts.filters) {
-                filters = JSON.parse(opts.filters);
-            }
-
-            if (filters && Object.keys(filters).indexOf('label') !== -1) {
-                labelFilters = utils.getLabelFilters({
-                    apiVersion: opts.clientApiVersion,
-                    log: log
-                }, filters['label']);
-
-                if (labelFilters instanceof Error) {
-                    invalidFilter = true;
-                }
+            if (filters && filters.hasOwnProperty('label')) {
+                labelFilters = filters['label'];
+                assert.array(labelFilters, 'labelFilters');
 
                 for (i = 0; i < labelFilters.length; i++) {
                     labelSplit = labelFilters[i].split('=', 2);
@@ -2419,11 +2419,6 @@ function getContainers(opts, callback) {
                         }
                     }
                 }
-            }
-
-            if (invalidFilter) {
-                cb(new errors.DockerError('invalid filters specified'));
-                return;
             }
 
             if (invalidPackageName) {
@@ -2467,16 +2462,14 @@ function getContainers(opts, callback) {
                 cb();
             });
         }, function _filterFilter(stash, cb) {
-            var filters;
             var filterErr;
             var objects = stash.objects;
 
-            if (!opts.filters) {
+            if (!filters) {
                 cb();
                 return;
             }
 
-            filters = JSON.parse(opts.filters);
             Object.keys(filters).forEach(function _filterField(field) {
                 var labelFilters;
                 var val = filters[field];
@@ -2540,16 +2533,7 @@ function getContainers(opts, callback) {
                         return false;
                     });
                 } else if (field == 'label') {
-                    labelFilters = utils.getLabelFilters({
-                        apiVersion: opts.clientApiVersion,
-                        log: log
-                    }, filters[field]);
-
-                    // _preloadPackages should already have validated, so we
-                    // just make sure here we don't get an error. If we do, this
-                    // is a programmer error.
-                    assert.ok(!(labelFilters instanceof Error),
-                        'getLabelFilters should not error');
+                    labelFilters = val;
 
                     // labelFilters is an *array* of acceptable docker name's
                     // *strings*, so find any containers matching *all* of the

--- a/lib/backends/sdc/images.js
+++ b/lib/backends/sdc/images.js
@@ -151,6 +151,11 @@ function listImages(opts, callback) {
     var log = opts.log;
     var dockerImages = [];
     var imageFilters = JSON.parse(opts.filters || '{}');
+    imageFilters = utils.getNormalizedFilters({ log: log }, imageFilters);
+    if (imageFilters instanceof Error) {
+        callback(new errors.DockerError('invalid filters: ' + imageFilters));
+        return;
+    }
 
     var funcs = [];
     if (!opts.skip_smartos) {
@@ -216,7 +221,6 @@ function listImages(opts, callback) {
 
     function imageFilter(img) {
         var isMatch = true;
-        var labelFilters;
 
         Object.keys(imageFilters).forEach(function (field) {
             var val = imageFilters[field];
@@ -231,18 +235,9 @@ function listImages(opts, callback) {
             } else if (field === 'label') {
                 // val is an *array* of acceptable image labels's *strings*, so
                 // check if image matches *all* of the requested values.
-                labelFilters = utils.getLabelFilters({
-                    apiVersion: opts.clientApiVersion,
-                    log: log
-                }, val);
-
-                if (labelFilters instanceof Error) {
-                    throw labelFilters;
-                }
-
                 var imgLabelsObj = img.config.Labels || {};
                 var imgLabelNames = Object.keys(imgLabelsObj);
-                if (!labelFilters.every(function (wantedLabelData) {
+                if (!val.every(function (wantedLabelData) {
                     // wantedLabelData is in format 'key=value'
                     var split = wantedLabelData.split('=', 2);
                     var wantedLabel = split[0];

--- a/lib/backends/sdc/images.js
+++ b/lib/backends/sdc/images.js
@@ -151,7 +151,7 @@ function listImages(opts, callback) {
     var log = opts.log;
     var dockerImages = [];
     var imageFilters = JSON.parse(opts.filters || '{}');
-    imageFilters = utils.getNormalizedFilters({ log: log }, imageFilters);
+    imageFilters = utils.getNormalizedFilters(imageFilters);
     if (imageFilters instanceof Error) {
         callback(new errors.DockerError('invalid filters: ' + imageFilters));
         return;

--- a/lib/backends/sdc/utils.js
+++ b/lib/backends/sdc/utils.js
@@ -116,16 +116,13 @@ function getPublishingRules(opts, fwrules) {
  *
  *     filters={"label":{"com.joyent.package=sample-2G":true, "foo=bar":true}}
  *
- * This function takes the filters object and returns a new normalized object
- * with each object value being an array instance.
+ * This function accepts either format and returns an object in the 1.9.1
+ * (array) format.
  */
-function getNormalizedFilters(opts, filters) {
-    assert.object(opts, 'opts');
-    assert.object(opts.log, 'opts.log');
+function getNormalizedFilters(filters) {
     assert.object(filters, 'filters');
 
     var i;
-    var log = opts.log;
     var name;
     var names = Object.keys(filters);
     var newFilters = {};
@@ -140,12 +137,9 @@ function getNormalizedFilters(opts, filters) {
             // Convert to an array of keys.
             newFilters[name] = Object.keys(val);
         } else {
-            log.warn({
-                filters: filters,
-                type: typeof (val),
-                val: JSON.stringify(val)
-            }, 'WARNING: filter %s is not an array or object', name);
-            return new Error('invalid filters');
+            return new Error(format(
+                'invalid filter "%s" - expected an array or object, got: %j',
+                name, val));
         }
     }
 

--- a/lib/backends/sdc/utils.js
+++ b/lib/backends/sdc/utils.js
@@ -110,45 +110,46 @@ function getPublishingRules(opts, fwrules) {
  *
  * In 1.9.1:
  *
- *     filters={"label":["com.joyent.package=sample-2G"]}
+ *     filters={"label":["com.joyent.package=sample-2G", "foo=bar"]}
  *
  * In 1.10.0:
  *
- *     filters={"label":{"com.joyent.package=sample-2G":true}}
+ *     filters={"label":{"com.joyent.package=sample-2G":true, "foo=bar":true}}
  *
- * This function takes the filters[label] value (as the filters parameter here)
- * and returns a normalized array of the packages we want to filter on.
- *
+ * This function takes the filters object and returns a new normalized object
+ * with each object value being an array instance.
  */
-function getLabelFilters(opts, filters) {
+function getNormalizedFilters(opts, filters) {
     assert.object(opts, 'opts');
-    assert.number(opts.apiVersion, 'opts.apiVersion');
     assert.object(opts.log, 'opts.log');
     assert.object(filters, 'filters');
 
+    var i;
     var log = opts.log;
-    var val = filters;
+    var name;
+    var names = Object.keys(filters);
+    var newFilters = {};
+    var val;
 
-    if ((common.apiVersionCmp(opts.apiVersion, 1.22) >= 0)
-        && !Array.isArray(val)) {
-        // the version is >= 1.22 and we got a non array object, convert to
-        // array based on keys.
-        val = Object.keys(val);
+    for (i = 0; i < names.length; i++) {
+        name = names[i];
+        val = filters[name];
+        if (Array.isArray(val)) {
+            newFilters[name] = val; // Nothing to convert.
+        } else if (typeof (val) === 'object') {
+            // Convert to an array of keys.
+            newFilters[name] = Object.keys(val);
+        } else {
+            log.warn({
+                filters: filters,
+                type: typeof (val),
+                val: JSON.stringify(val)
+            }, 'WARNING: filter %s is not an array or object', name);
+            return new Error('invalid filters');
+        }
     }
 
-    // val should have either been an array, or we should have turned it into
-    // one. Any other value is illegal.
-    if (!Array.isArray(val)) {
-        log.warn({
-            filters: filters,
-            type: typeof (val),
-            val: JSON.stringify(val)
-        }, 'WARNING: filter value is not an array');
-
-        return new Error('invalid filter');
-    }
-
-    return (val);
+    return newFilters;
 }
 
 function getPublishedPorts(opts, fwrules, cb) {
@@ -915,7 +916,7 @@ function compressPorts(ports) {
 module.exports = {
     compressPorts: compressPorts,
     vmUuidToShortDockerId: vmUuidToShortDockerId,
-    getLabelFilters: getLabelFilters,
+    getNormalizedFilters: getNormalizedFilters,
     getPublishedPorts: getPublishedPorts,
     isValidDockerConatinerName: isValidDockerConatinerName,
     imgobjToInspect: imgobjToInspect,

--- a/test/integration/cli-filters.test.js
+++ b/test/integration/cli-filters.test.js
@@ -1,0 +1,139 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (c) 2016, Joyent, Inc.
+ */
+
+/*
+ * Integration tests for docker labels.
+ */
+
+var format = require('util').format;
+var test = require('tape');
+var vasync = require('vasync');
+
+var cli = require('../lib/cli');
+var common = require('../lib/common');
+var vm = require('../lib/vm');
+
+
+// --- Globals
+
+var CLIENTS = {};
+var CONTAINER_PREFIX = 'sdcdockertest_filters_';
+var IMAGE_NAME = 'joyent/busybox_with_label_test';
+
+
+
+// --- Tests
+
+test('setup', function (tt) {
+
+    tt.test('DockerEnv: alice init', cli.init);
+
+    tt.test('vmapi client', vm.init);
+});
+
+
+function checkContainerFiltering(tt, args, expectedNames) {
+    tt.test('container filtering', function (t) {
+        cli.ps(t, {args: args}, function (err, containers) {
+            console.log('containers: ', containers);
+            t.ifErr(err, 'docker ps ' + args);
+            t.equal(containers.length, expectedNames.length, 'Container count');
+            var gotNames = containers.map(function (c) { return c.names; });
+            t.deepEqual(gotNames.sort(), expectedNames.sort(),
+                'Container names');
+            t.end();
+        });
+    });
+}
+
+
+test('container filters', function (tt) {
+    var containerName1 = common.makeContainerName(CONTAINER_PREFIX);
+    var containerName2 = common.makeContainerName(CONTAINER_PREFIX);
+
+    tt.test('create container 1', function (t) {
+        var runArgs = format('-d --name %s --label fishing=true %s sleep 3600',
+            containerName1, IMAGE_NAME);
+        cli.run(t, {args: runArgs}, function (err, id) {
+            t.ifErr(err, 'docker run ' + IMAGE_NAME);
+            t.end();
+        });
+    });
+
+    tt.test('create container 2', function (t) {
+        var runArgs = format('-d --name %s --label fishing=fun %s sleep 3600',
+            containerName2, IMAGE_NAME);
+        cli.run(t, {args: runArgs}, function (err, id) {
+            t.ifErr(err, 'docker run ' + IMAGE_NAME);
+            t.end();
+        });
+    });
+
+    // Filtering on the container label that comes from the image.
+    checkContainerFiltering(tt, '--filter label=todd=cool',
+        [containerName1, containerName2]);
+
+    // Filtering on just the label name.
+    checkContainerFiltering(tt, '--filter label=fishing',
+        [containerName1, containerName2]);
+
+    // Filtering on just the label name and value, which exists.
+    checkContainerFiltering(tt, '--filter label=fishing=fun', [containerName2]);
+
+    // Filtering on just the label name and value, which doesn't exist.
+    checkContainerFiltering(tt, '--filter label=fishing=notfun', []);
+
+    // Filtering on the container name prefix.
+    checkContainerFiltering(tt, '--filter name=' + CONTAINER_PREFIX,
+        [containerName1, containerName2]);
+
+    // Filtering on the full container name.
+    checkContainerFiltering(tt, '--filter name=' + containerName1,
+        [containerName1]);
+
+    // Filtering using multiple filters matching both containers.
+    checkContainerFiltering(tt, '--filter name=' + CONTAINER_PREFIX
+        + ' --filter label=fishing'
+        + ' --filter label=todd=cool',
+        [containerName1, containerName2]);
+
+    // Filtering using multiple filters matching just one container.
+    checkContainerFiltering(tt, '--filter name=' + CONTAINER_PREFIX
+        + ' --filter label=fishing=fun'
+        + ' --filter label=todd=cool',
+        [containerName2]);
+});
+
+
+test('image filters', function (tt) {
+    tt.test('filter on image label', function (t) {
+        cli.images(t, {args: '--filter label=todd=cool'},
+            function (err, images)
+        {
+            t.ifErr(err, 'docker images --filter');
+            t.equal(images.length, 1, 'Check one image returned');
+            t.equal(images[0].repository, IMAGE_NAME, 'Check image name');
+            t.end();
+        });
+    });
+
+    tt.test('filter on nonexistant image label', function (t) {
+        cli.images(t, {args: '--filter label=todd=notcool'},
+            function (err, images)
+        {
+            t.ifErr(err, 'docker images nonexistant --filter');
+            t.deepEqual(images, []);
+            t.end();
+        });
+    });
+});
+
+
+test('teardown', cli.rmAllCreated);

--- a/test/integration/cli-labels.test.js
+++ b/test/integration/cli-labels.test.js
@@ -153,39 +153,4 @@ test('labels conflict', function (tt) {
 });
 
 
-test('labels image filtering', function (tt) {
-    // Ensure the mybusybox image is available.
-    tt.test('image label', function (t) {
-        var runArgs = format('-d --name %s %s sleep 3600',
-            common.makeContainerName(CONTAINER_PREFIX), IMAGE_NAME);
-        cli.run(t, {args: runArgs}, function (err, id) {
-            t.ifErr(err, 'docker run ' + IMAGE_NAME);
-            t.end();
-        });
-    });
-
-
-    tt.test('filter on image label', function (t) {
-        cli.images(t, {args: '--filter label=todd=cool'},
-            function (err, images)
-        {
-            t.ifErr(err, 'docker images --filter');
-            t.equal(images.length, 1, 'Check one image returned');
-            t.equal(images[0].repository, IMAGE_NAME, 'Check image name');
-            t.end();
-        });
-    });
-
-    tt.test('filter on nonexistant image label', function (t) {
-        cli.images(t, {args: '--filter label=todd=notcool'},
-            function (err, images)
-        {
-            t.ifErr(err, 'docker images nonexistant --filter');
-            t.deepEqual(images, []);
-            t.end();
-        });
-    });
-});
-
-
 test('teardown', cli.rmAllCreated);

--- a/test/integration/cli-labels.test.js
+++ b/test/integration/cli-labels.test.js
@@ -166,35 +166,22 @@ test('labels image filtering', function (tt) {
 
 
     tt.test('filter on image label', function (t) {
-        cli.docker('images --filter label=todd=cool',
-                    function (err, stdout, stderr)
+        cli.images(t, {args: '--filter label=todd=cool'},
+            function (err, images)
         {
             t.ifErr(err, 'docker images --filter');
-            var lines = stdout.split('\n');
-
-            if (lines.filter(function (line) {
-                return line.substr(0, IMAGE_NAME.length) === IMAGE_NAME;
-                }).length === 0)
-            {
-                t.fail('Filter did not return the expected image: ' + stdout);
-            }
+            t.equal(images.length, 1, 'Check one image returned');
+            t.equal(images[0].repository, IMAGE_NAME, 'Check image name');
             t.end();
         });
     });
 
-    tt.test('filter on bogus image label', function (t) {
-        cli.docker('images --filter label=todd=notcool',
-                    function (err, stdout, stderr)
+    tt.test('filter on nonexistant image label', function (t) {
+        cli.images(t, {args: '--filter label=todd=notcool'},
+            function (err, images)
         {
-            t.ifErr(err, 'docker images --filter');
-            var lines = stdout.split('\n');
-
-            if (lines.filter(function (line) {
-                return line.substr(0, IMAGE_NAME.length) === IMAGE_NAME;
-                }).length !== 0)
-            {
-                t.fail('Filter returned an expected image: ' + stdout);
-            }
+            t.ifErr(err, 'docker images nonexistant --filter');
+            t.deepEqual(images, []);
             t.end();
         });
     });

--- a/test/lib/common.js
+++ b/test/lib/common.js
@@ -252,7 +252,7 @@ function makeContainerName(prefix) {
 
 
 /*
- * Parse docker columnar output by using the width's in the first header row.
+ * Parse docker columnar output by using the widths in the first header row.
  */
 function parseOutputUsingHeader(stdout, opts) {
     var entries = [];


### PR DESCRIPTION
With Docker 1.10 (API version 1.22) the filters changed from an array to an
object with the value true.

In 1.9.1: 
```json
    filters={"label":["com.joyent.package=sample-2G", "foo=bar"]}
```

In 1.10.0:
```json
    filters={"label":{"com.joyent.package=sample-2G":true, "foo=bar":true}}
```