### PR TITLE
Support enabledLogDrivers comma-separated list with spaces in it

### DIFF
--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -26,7 +26,10 @@ function loadConfigSync(opts) {
     // make sure that no driver was specified that doesn't actually exist.
     if (config.enabledLogDrivers) {
         assert.string(config.enabledLogDrivers, 'config.enabledLogDrivers-raw');
-        config.enabledLogDrivers = config.enabledLogDrivers.split(',');
+        config.enabledLogDrivers = config.enabledLogDrivers.split(',')
+            .map(function (driver) {
+                return driver.trim();
+            });
     } else {
         config.enabledLogDrivers = ['json-file'];
     }


### PR DESCRIPTION
This takes care of #108.

Allows for `config.enabledLogDrivers` to have a list like `"json-file, none"`, `split(",")` it, and not break the way the code validates the driver by trimming the spaces surrounding each item in the array of strings.