### PR TITLE
remove support for name generation, leave that up to volapi

### DIFF
--- a/lib/endpoints/volumes.js
+++ b/lib/endpoints/volumes.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2016, Joyent, Inc.
+ * Copyright (c) 2017, Joyent, Inc.
  */
 
 var assert = require('assert-plus');
@@ -55,10 +55,6 @@ function createVolume(req, res, next) {
         network: networkParams,
         type: req.params.Driver
     };
-
-    if (volumeParams.name === '') {
-        volumeParams.name = mod_volumes.generateVolumeName();
-    }
 
     // The 'local' volume driver is used by default and implicitly by at least
     // several Docker clients when creating a volume (including the docker

--- a/lib/volumes.js
+++ b/lib/volumes.js
@@ -60,6 +60,5 @@ function parseVolumeSize(size) {
 
 module.exports = {
     DEFAULT_DRIVER: DEFAULT_DRIVER,
-    generateVolumeName: generateVolumeName,
     parseVolumeSize: parseVolumeSize
 };

--- a/lib/volumes.js
+++ b/lib/volumes.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2016, Joyent, Inc.
+ * Copyright (c) 2017, Joyent, Inc.
  */
 
 var assert = require('assert-plus');
@@ -14,18 +14,6 @@ var libuuid = require('libuuid');
 var units = require('./units');
 
 var DEFAULT_DRIVER = 'tritonnfs';
-
-/*
- * Returns a string representing a unique volume name.
- */
-function generateVolumeName() {
-    // The format of an automatically generated volume name is a string of 64
-    // characters representing hexadecimal numbers. It comes from Docker's
-    // implementation for local volumes:
-    // https://github.com/docker/docker/blob/master/daemon/create.go#L211 and
-    // https://github.com/docker/docker/blob/master/pkg/stringid/stringid.go#L53
-    return (libuuid.create() + libuuid.create()).replace(/-/g, '');
-}
 
 function throwInvalidSize(size) {
     assert.string(size, 'size');


### PR DESCRIPTION
VOLAPI-48 will have volapi creating volume names when names are missing. We should let it do this and not generate the names ourselves in a different way at sdc-docker.