### PR TITLE
TRITON-2077 docker cp should support parallel file copying

### DIFF
--- a/lib/backends/sdc/containers.js
+++ b/lib/backends/sdc/containers.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 var child_process = require('child_process');
@@ -4386,6 +4386,7 @@ function dockerCopy(opts, callback) {
     assert.string(opts.req_id, 'opts.req_id');
     assert.object(opts.account, 'opts.account');
     assert.object(opts.cnapi, 'opts.cnapi');
+    assert.object(opts.vm, 'opts.vm');
 
     var log = opts.log;
     var cnapi = opts.cnapi;
@@ -4420,133 +4421,91 @@ function dockerCopy(opts, callback) {
 /**
  * Sends a task to the cn-agent on a compute node which starts a TCP server on
  * the compute node and then returns to us the server's address and port. We
- * then connect to that server and pipe it's stream to the our client.
+ * then connect to that server and then pipe our client's stream to/from it.
  */
-
-function containerArchiveReadStream(opts, callback) {
+function containerArchiveStream(opts, callback) {
     assert.object(opts, 'opts');
+    assert.string(opts.mode, 'opts.mode');
+    assert.string(opts.path, 'opts.path');
     assert.object(opts.log, 'opts.log');
+    assert.string(opts.req_id, 'opts.req_id');
+    assert.object(opts.cnapi, 'opts.cnapi');
     assert.object(opts.vm, 'opts.vm');
-    assert.string(opts.req_id, 'opts.req_id');
-    assert.object(opts.cnapi, 'opts.cnapi');
-    assert.string(opts.path, 'opts.path');
+
+    // On success, result will end up looking like:
+    //  {
+    //    ticket: { ... cnapi waitlist ticket object ...},
+    //    socket: { ... cnapi socket object ...},
+    //    containerPathStat: { ... stats object, if mode is 'read', 'stat' ... }
+    //  }
+    var result = {};
 
     var log = opts.log;
     var cnapi = opts.cnapi;
     var copyHeaders = { headers: { 'x-request-id': opts.req_id } };
-
-    cnapi.dockerCopy(opts.vm.server_uuid, opts.vm.uuid, {
-        path: opts.path,
-        mode: 'read'
-    }, copyHeaders, onCopy);
-
-    function onCopy(copyErr, res) {
-        if (copyErr) {
-            log.error(copyErr, 'error calling docker-copy');
-            if (copyErr.restCode === 'VmNotRunning') {
-                return callback(new errors.NotImplementedError(
-                    'copy on stopped container'));
-            }
-            return callback(errors.cnapiErrorWrap(
-                copyErr, 'problem calling docker copy'));
-        }
-
-        var host = res.host;
-        var port = res.port;
-
-        var copySocket = net.createConnection({ host: host, port: port });
-
-        callback(null, copySocket, {
-            containerPathStat: res.containerPathStat });
-    }
-}
-
-
-/**
- * Sends a task to the cn-agent on a compute node which starts a TCP server on
- * the compute node and then returns to us the server's address and port. We
- * then connect to that server and then pipe our client's steam into it.
- */
-
-function containerArchiveWriteStream(opts, callback) {
-    assert.object(opts, 'opts');
-    assert.string(opts.path, 'opts.path');
-    assert.object(opts.log, 'opts.log');
-    assert.string(opts.req_id, 'opts.req_id');
-    assert.object(opts.cnapi, 'opts.cnapi');
-
-    var log = opts.log;
-    var cnapi = opts.cnapi;
-    var copyHeaders = { headers: { 'x-request-id': opts.req_id } };
-
     var copyOpts = {
         path: opts.path,
-        mode: 'write'
+        mode: opts.mode
     };
 
     if (opts.no_overwrite_dir) {
         copyOpts.no_overwrite_dir = true;
     }
 
-    cnapi.dockerCopy(
-        opts.vm.server_uuid, opts.vm.uuid, copyOpts, copyHeaders, onCopy);
+    vasync.pipeline({ funcs: [
+        function createWaitlistTicket(_, next) {
+            var createOpts = {
+                actionDescription: 'docker copy ' + opts.mode,
+                cnapi: cnapi,
+                log: log,
+                vm: opts.vm
+            };
+            common.createVMWaitTicket(createOpts,
+                    function _onCreateCb(err, ticket) {
+                result.ticket = ticket;
+                next(err);
+            });
+        },
+        function waitForWaitlistTicket(_, next) {
+            log.debug({mode: opts.mode, path: opts.path},
+                'archiveStream: acquiring waitlist ticket');
+            var waitOpts = {
+                cnapi: cnapi,
+                log: log,
+                ticket: result.ticket
+            };
+            common.waitOnVMWaitTicket(waitOpts, next);
+        },
+        function getCnapiSocketDetails(_, next) {
+            log.debug({mode: opts.mode, path: opts.path},
+                'archiveStream: calling dockerCopy');
+            cnapi.dockerCopy(opts.vm.server_uuid, opts.vm.uuid, copyOpts,
+                    copyHeaders,
+                    function _onCopyCb(err, res) {
+                if (err) {
+                    log.error(err, 'error calling docker-copy');
+                    if (err.restCode === 'VmNotRunning') {
+                        next(new errors.NotImplementedError(
+                            'copy on stopped container'));
+                        return;
+                    }
+                    next(errors.cnapiErrorWrap(
+                        err, 'problem calling docker copy'));
+                    return;
+                }
 
-    function onCopy(copyErr, res) {
-        if (copyErr) {
-            log.error(copyErr, 'error calling docker-copy');
-            if (copyErr.restCode === 'VmNotRunning') {
-                return callback(new errors.NotImplementedError(
-                    'copy on stopped container'));
-            }
-            return callback(errors.cnapiErrorWrap(
-                copyErr, 'problem calling docker copy'));
+                result.containerPathStat = res && res.containerPathStat;
+                var createOpts = {
+                    host: res.host,
+                    port: res.port
+                };
+                result.socket = net.createConnection(createOpts);
+                next();
+            });
         }
-
-        var host = res.host;
-        var port = res.port;
-
-        var copySocket = net.createConnection({ host: host, port: port });
-
-        callback(null, copySocket);
-    }
-}
-
-
-/**
- * Sends a task to cn-agent on a server and have it stat a file within the
- * container.
- */
-
-function containerArchiveStat(opts, callback) {
-    assert.object(opts, 'opts');
-    assert.object(opts.log, 'opts.log');
-    assert.object(opts.vm, 'opts.vm');
-    assert.string(opts.req_id, 'opts.req_id');
-    assert.object(opts.cnapi, 'opts.cnapi');
-    assert.string(opts.path, 'opts.path');
-
-    var log = opts.log;
-    var cnapi = opts.cnapi;
-    var copyHeaders = { headers: { 'x-request-id': opts.req_id } };
-
-    cnapi.dockerCopy(opts.vm.server_uuid, opts.vm.uuid, {
-        path: opts.path,
-        mode: 'stat'
-    }, copyHeaders, onCopy);
-
-    function onCopy(copyErr, res) {
-        if (copyErr) {
-            log.error(copyErr, 'error calling docker-copy');
-            if (copyErr.restCode === 'VmNotRunning') {
-                return callback(new errors.NotImplementedError(
-                    'copy on stopped container'));
-            }
-            return callback(errors.cnapiErrorWrap(
-                copyErr, 'problem calling docker copy'));
-        }
-
-        callback(null, { containerPathStat: res.containerPathStat });
-    }
+    ]}, function _pipelineCb(err) {
+        callback(err, result);
+    });
 }
 
 
@@ -4587,9 +4546,7 @@ module.exports = {
     containerLogs: containerLogs,
     containerStats: containerStats,
     copyContainer: copyContainer,
-    containerArchiveReadStream: containerArchiveReadStream,
-    containerArchiveWriteStream: containerArchiveWriteStream,
-    containerArchiveStat: containerArchiveStat,
+    containerArchiveStream: containerArchiveStream,
     createContainer: createContainer,
     deleteContainer: deleteContainer,
     deleteLink: deleteLink,

--- a/lib/backends/sdc/index.js
+++ b/lib/backends/sdc/index.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2018, Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 /*
@@ -57,12 +57,7 @@ SdcBackend.prototype.startContainer = containers.startContainer;
 SdcBackend.prototype.stopContainer = containers.stopContainer;
 SdcBackend.prototype.waitContainer = containers.waitContainer;
 SdcBackend.prototype.copyContainer = containers.copyContainer;
-SdcBackend.prototype.containerArchiveReadStream =
-    containers.containerArchiveReadStream;
-SdcBackend.prototype.containerArchiveWriteStream =
-    containers.containerArchiveWriteStream;
-SdcBackend.prototype.containerArchiveStat =
-    containers.containerArchiveStat;
+SdcBackend.prototype.containerArchiveStream = containers.containerArchiveStream;
 
 // images.js
 SdcBackend.prototype.deleteImage = images.deleteImage;

--- a/lib/common.js
+++ b/lib/common.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2018, Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 var assert = require('assert-plus');
@@ -823,6 +823,81 @@ function apiVersionCmp(A, B)
     return (Number(aMatch[2]) - Number(bMatch[2]));
 }
 
+
+function createVMWaitTicket(opts, callback) {
+    assert.string(opts.actionDescription, 'opts.actionDescription');
+    assert.object(opts.cnapi, 'opts.cnapi');
+    assert.object(opts.log, 'opts.log');
+    assert.object(opts.vm, 'opts.vm');
+    assert.uuid(opts.vm.uuid, 'opts.vm.uuid');
+    assert.uuid(opts.vm.server_uuid, 'opts.vm.server_uuid');
+
+    var cnapi = opts.cnapi;
+    var server_uuid = opts.vm.server_uuid;
+
+    var expiryMs = 600 * 1000;
+    var newTicket = {
+        action: opts.action,
+        expires_at: (new Date(Date.now() + expiryMs).toISOString()),
+        id: opts.vm.uuid,
+        scope: 'vm'
+    };
+
+    cnapi.waitlistTicketCreate(server_uuid, newTicket,
+            function _onCreateWaitTicketCb(err, ticket) {
+        if (err) {
+            opts.log.warn({action: opts.action},
+                'createVmWaitTicket: waitlist ticket create failed: %s', err);
+        } else {
+            opts.log.debug({action: opts.action, uuid: ticket.uuid},
+                'createVmWaitTicket: waitlist ticket created successfully');
+        }
+
+        callback(err, ticket);
+    });
+}
+
+
+function waitOnVMWaitTicket(opts, callback) {
+    assert.object(opts.cnapi, 'opts.cnapi');
+    assert.object(opts.log, 'opts.log');
+    assert.object(opts.ticket, 'opts.ticket');
+
+    opts.cnapi.waitlistTicketWait(opts.ticket.uuid,
+            function _onWaitTicketCb(err, ticket) {
+        if (err) {
+            opts.log.warn({ticket: ticket},
+                'waitOnVMWaitTicket: failed waiting for ticket: %s', err);
+        } else {
+            opts.log.debug({ticket: ticket},
+                'waitOnVMWaitTicket: waitlist ticket acquired');
+        }
+
+        callback(err, ticket);
+    });
+}
+
+
+function releaseVMWaitTicket(opts, callback) {
+    assert.object(opts.cnapi, 'opts.cnapi');
+    assert.object(opts.log, 'opts.log');
+    assert.object(opts.ticket, 'opts.ticket');
+
+    opts.cnapi.waitlistTicketRelease(opts.ticket.uuid,
+            function _onReleaseWaitTicketCb(err) {
+        if (err) {
+            opts.log.warn({uuid: opts.ticket.uuid},
+                'releaseVMWaitTicket: release waitlist ticket failed: %s', err);
+        } else {
+            opts.log.debug({uuid:opts.ticket.uuid},
+                'releaseVMWaitTicket: released waitlist ticket');
+        }
+
+        callback(err);
+    });
+}
+
+
 module.exports = {
     apiVersionCmp: apiVersionCmp,
     reqClientApiVersion: reqClientApiVersion,
@@ -848,6 +923,9 @@ module.exports = {
     generateDockerId: generateDockerId,
     formatProgress: formatProgress,
     waitForJob: waitForJob,
+    createVMWaitTicket: createVMWaitTicket,
+    waitOnVMWaitTicket: waitOnVMWaitTicket,
+    releaseVMWaitTicket: releaseVMWaitTicket,
     LABELTAG_PREFIX: LABELTAG_PREFIX,
     LOG_DRIVERS: LOG_DRIVERS
 };

--- a/lib/endpoints/containers.js
+++ b/lib/endpoints/containers.js
@@ -732,26 +732,37 @@ function containerCopy(req, res, next) {
 function containerReadArchive(req, res, next) {
     // pass in req_id: req.getId()
     var log = req.log;
+    var ticket;
 
-    req.log.debug({req: req}, 'req');
+    log.debug({req: req}, 'req');
 
     var opts = {
         log: log,
         cnapi: req.app.cnapi,
+        mode: 'read',
         req_id: req.getId(),
         vm: req.vm,
         path: req.query.path
     };
 
-    req.backend.containerArchiveReadStream(opts, onReadStream);
+    req.backend.containerArchiveStream(opts, onReadStream);
 
-    function onReadStream(err, readSocket, extras) {
+    function onReadStream(err, result) {
+        ticket = result.ticket;
+
         if (err) {
-            return next(err);
+            releaseWaitlistTicket(err, next);
+            return;
         }
 
+        assert.object(result, 'result');
+        assert.object(result.socket, 'result.socket');
+        assert.object(result.containerPathStat, 'result.containerPathStat');
+
+        var readSocket = result.socket;
+
         var statHeader = new Buffer(JSON.stringify(
-            extras.containerPathStat)).toString('base64');
+            result.containerPathStat)).toString('base64');
 
         readSocket.on('connect', function () {
             res.setHeader('content-type', 'application/tar');
@@ -781,8 +792,43 @@ function containerReadArchive(req, res, next) {
                 readSocket.destroy();
             });
 
+            readSocket.on('close', function _onReadSocketClose() {
+                log.debug('read socket closed - releasing waitlist ticket');
+                releaseWaitlistTicket();
+            });
+
             readSocket.pipe(res);
+
             next();
+        });
+    }
+
+    // Release the CNAPI waitlist ticket if it's held.
+    function releaseWaitlistTicket(err, cb) {
+        if (!ticket) {
+            if (cb) {
+                cb();
+            }
+            return;
+        }
+
+        var releaseOpts = {
+            cnapi: req.app.cnapi,
+            log: log,
+            ticket: ticket
+        };
+
+        ticket = null;
+
+        common.releaseVMWaitTicket(releaseOpts,
+                function _onReleaseCb(releaseErr) {
+            if (releaseErr) {
+                log.warn('Unable to release docker copy vm waitlist ticket',
+                    releaseErr);
+            }
+            if (cb) {
+                cb(err || releaseErr);
+            }
         });
     }
 }
@@ -794,11 +840,13 @@ function containerReadArchive(req, res, next) {
 function containerWriteArchive(req, res, next) {
     // pass in req_id: req.getId()
     var log = req.log;
+    var ticket;
 
-    req.log.debug({req: req}, 'req');
+    log.debug({req: req}, 'req');
 
     var opts = {
         log: log,
+        mode: 'write',
         path: req.query.path,
         cnapi: req.app.cnapi,
         req_id: req.getId(),
@@ -810,13 +858,21 @@ function containerWriteArchive(req, res, next) {
         opts.no_overwrite_dir = common.boolFromQueryParam(noOverwriteDirNonDir);
     }
 
-    req.backend.containerArchiveWriteStream(
+    req.backend.containerArchiveStream(
         opts, onContainerArchiveWriteStream);
 
-    function onContainerArchiveWriteStream(err, archiveSocket) {
+    function onContainerArchiveWriteStream(err, result) {
+        ticket = result.ticket;
+
         if (err) {
-            return next(err);
+            done(err);
+            return;
         }
+
+        assert.object(result, 'result');
+        assert.object(result.socket, 'result.socket');
+
+        var archiveSocket = result.socket;
 
         archiveSocket.on('connect', function () {
             res.setHeader('content-type', 'text/plain');
@@ -841,8 +897,32 @@ function containerWriteArchive(req, res, next) {
                     res.send(200);
                 }
 
-                next();
+                done();
             });
+        });
+    }
+
+    // Release the CNAPI waitlist ticket if it's held.
+    function done(err) {
+        if (!ticket) {
+            next(err);
+            return;
+        }
+
+        var releaseOpts = {
+            cnapi: req.app.cnapi,
+            log: log,
+            ticket: ticket
+        };
+        common.releaseVMWaitTicket(releaseOpts,
+                function _onReleaseCb(releaseErr) {
+            // Log 'releaseErr', but callback with the original 'err'.
+            if (releaseErr) {
+                log.warn('Unable to release docker copy vm waitlist ticket',
+                    releaseErr);
+            }
+            ticket = null;
+            next(err);
         });
     }
 }
@@ -854,30 +934,59 @@ function containerWriteArchive(req, res, next) {
 function containerStatArchive(req, res, next) {
     // pass in req_id: req.getId()
     var log = req.log;
+    var ticket;
 
-    req.log.debug({req: req}, 'req');
+    log.debug({req: req}, 'req');
 
     var opts = {
         log: log,
         cnapi: req.app.cnapi,
+        mode: 'stat',
         req_id: req.getId(),
         vm: req.vm,
         path: req.query.path
     };
 
-    req.backend.containerArchiveStat(opts, function onStat(err, extras) {
+    req.backend.containerArchiveStream(opts, function onStat(err, result) {
+        ticket = result.ticket;
+
         if (err) {
-            return next(err);
+            done(err);
+            return;
         }
 
         var statHeader = new Buffer(JSON.stringify(
-            extras.containerPathStat)).toString('base64');
+            result.containerPathStat)).toString('base64');
 
         res.setHeader('x-docker-container-path-stat', statHeader);
 
         res.send(200);
-        next();
+        done();
     });
+
+    // Release the CNAPI waitlist ticket if it's held.
+    function done(err) {
+        if (!ticket) {
+            next(err);
+            return;
+        }
+
+        var releaseOpts = {
+            cnapi: req.app.cnapi,
+            log: log,
+            ticket: ticket
+        };
+        common.releaseVMWaitTicket(releaseOpts,
+                function _onReleaseCb(releaseErr) {
+            // Log 'releaseErr', but callback with the original 'err'.
+            if (releaseErr) {
+                log.warn('Unable to release docker stat vm waitlist ticket',
+                    releaseErr);
+            }
+            ticket = null;
+            next(err);
+        });
+    }
 }
 
 

--- a/lib/endpoints/containers.js
+++ b/lib/endpoints/containers.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2017, Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 var assert = require('assert-plus');
@@ -712,16 +712,6 @@ function containerCopy(req, res, next) {
 
         copySocket.on('connect', function () {
             res.setHeader('content-type', 'application/tar');
-
-            var error;
-
-            copySocket.on('error', function (e) {
-                error = e;
-
-                opts.log.debug(
-                    'copySocket for %s threw an error %', opts.vm.uuid,
-                    error.toString());
-            });
 
             copySocket.on('error', function (e) {
                 opts.log.error(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sdc-docker",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "author": "Joyent (joyent.com)",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
This essentially wraps the `docker cp` code paths with a CNAPI waitlist ticket, to avoid running multiple docker copy operations at the same time.

I also added more docker copy funky filename tests (for things that were previously failing - like single quotes and dollar sign handling), and the ability to run these tests in parallel (for both stopped and running containers) - previously they only ran sequentially.