### PR TITLE
TRITON-406 want clearer error message when a provision fails during DAPI server allocation

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2018, Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 /*
@@ -435,31 +435,6 @@ util.inherits(ExposedSDCError, _DockerBaseError);
 
 
 /**
- * Error to indicate we are "at capacity" and no servers can accomodate the
- * container requirements.
- *
- * Usage:
- *      new DockerNoComputeResourcesError();
- *      new DockerNoComputeResourcesError(cause);
- */
-function DockerNoComputeResourcesError(cause) {
-    var message = 'No compute resources available.';
-    _DockerBaseError.call(this, {
-        restCode: this.constructor.restCode,
-        statusCode: (cause && cause.statusCode) || this.constructor.statusCode,
-        message: message,
-        cause: cause
-    });
-}
-util.inherits(DockerNoComputeResourcesError, _DockerBaseError);
-DockerNoComputeResourcesError.prototype.name = 'DockerNoComputeResourcesError';
-DockerNoComputeResourcesError.restCode = 'DockerNoComputeResourcesError';
-DockerNoComputeResourcesError.statusCode = 409;
-DockerNoComputeResourcesError.description = 'No compute resources available.';
-
-
-
-/**
  * Error to indicate the server hosting the container we wish to "volumes-from"
  * into our container is unable to meet the resource requirements specified by
  * the provision request.
@@ -636,10 +611,8 @@ function vmapiErrorWrap(cause, message) {
 
     switch (cause.restCode) {
         case 'ValidationFailed':
-            return new ExposedSDCError(cause, message);
-
         case 'NoAllocatableServersError':
-            return new DockerNoComputeResourcesError();
+            return new ExposedSDCError(cause, message);
 
         case 'VolumesNotReachable':
             return new VolumesNotReachableError(cause);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sdc-docker",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "author": "Joyent (joyent.com)",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
There is a docker failure example (affinity failure).
```
$ docker run -d -e 'affinity:container==missing' busybox sh -c 'sleep 86400'
docker: Error response from daemon: (NoAllocatableServersError) problem creating container: No compute resources available: no active containers found matching "missing" for affinity "container==missing" (55f05740-9fa6-4250-ba7a-9994b7bc4c18).
See 'docker run --help'.
```