### PR TITLE
joyent/sdc-docker#159 want support for "administrator" role

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -110,13 +110,14 @@ function authTls(req, res, next) {
 
     var account;
     var ufdsKey;
+    var adminRoleMembers;
     var login = cert.subjects[0].cn;
-    var authFunctions = [ getMainAccount ];
+    var authFunctions = [ getMainAccount, getAdminRole ];
 
     if (authCache.get(login) && authCache.get(login) === peerKeyFp) {
         log.debug('Cached authentication found token for %s', login);
     } else {
-        authFunctions.push(getKey, verifyKey);
+        authFunctions.push(getKey, getAdminRoleKeys, verifyKey);
     }
 
     // No support for account subusers at the moment
@@ -138,12 +139,36 @@ function authTls(req, res, next) {
         });
     }
 
+    function getAdminRole(_, cb) {
+        var roleFilter = '(&(objectclass=sdcaccountrole)(name=administrator))';
+        ufds.listRoles(account.uuid, roleFilter, function (err, rs) {
+            if (err) {
+                cb();
+                return;
+            }
+
+            var adminRole = rs[0];
+            if (!adminRole || !adminRole.uniquememberdefault) {
+                cb();
+                return;
+            }
+
+            var members = adminRole.uniquememberdefault;
+            if (!Array.isArray(members)) {
+                members = [members];
+            }
+
+            adminRoleMembers = members;
+            cb();
+        });
+    }
+
     function getKey(_, cb) {
         ufds.getKey(account, lookupFp, function (err, key) {
             if (err) {
                 log.info({err: err, login: login, authn: true},
                     'ufds.getKey err');
-                cb(new errors.UnauthorizedError(err));
+                cb();
                 return;
             }
             ufdsKey = key;
@@ -151,7 +176,46 @@ function authTls(req, res, next) {
         });
     }
 
+    function getAdminRoleKeys(_, cb) {
+        if (ufdsKey) {
+            cb();
+            return;
+        }
+
+        vasync.forEachParallel({
+            func: getUserKey,
+            inputs: adminRoleMembers
+        }, cb);
+
+        function getUserKey(dn, ccb) {
+            /*
+             * Note scope: one not sub, the DN might be an account rather
+             * than a sub-user, and we don't want its sub-user's keys.
+             */
+            ufds.search(dn, {
+                scope: 'one',
+                filter: '(&(fingerprint=' + lookupFp + ')' +
+                    '(objectclass=sdckey))'
+            }, function (err2, userKeys) {
+                if (err2) {
+                    ccb(err2);
+                    return;
+                }
+                if (userKeys[0] && userKeys[0].pkcs) {
+                    ufdsKey = userKeys[0];
+                }
+                ccb();
+            });
+        }
+    }
+
     function verifyKey(_, cb) {
+        if (!ufdsKey) {
+            log.info({login: login, authn: true}, 'key not found');
+            cb(new errors.UnauthorizedError(err));
+            return;
+        }
+
         var key;
         try {
             key = sshpk.parseKey(ufdsKey.pkcs);


### PR DESCRIPTION
We've been running this on our sdc-docker at UQ for the last few months. It works with a change to node-triton to allow the use of the `--act-as` flag with `triton profile docker-setup` (https://github.com/eait-itig/node-triton/commit/e2b9d39ade282d54cbb298bd82d278670dfad869, which will be cleaned up and PR'd separately after this goes back)